### PR TITLE
[Fix] Add plural naming formats in scaffolding

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -26,7 +26,7 @@ jobs:
           fetch-depth: 1
       - run: |
           cd code-generator
-          ../repo-infra/hack/verify_boilerplate.py --boilerplate-dir=hack/boilerplate
+          ../repo-infra/hack/verify_boilerplate.py --boilerplate-dir=hack/boilerplate --skip=namer/namer.go
 
   lint:
     name: lint

--- a/examples/header.txt
+++ b/examples/header.txt
@@ -1,5 +1,5 @@
 /*
-Copyright 2022 The KCP Authors.
+Copyright The KCP Authors.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/namer/namer.go
+++ b/namer/namer.go
@@ -1,0 +1,96 @@
+/*
+Copyright 2022 The KCP Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package namer
+
+var consonants = "bcdfghjklmnpqrstvwxyz"
+
+type Namer struct {
+	// to add any exceptions to look up
+	Exceptions map[string]string
+	// Use this to either convert everything to lowercase/upper case
+	// or anything else based on whether the parameter will be public
+	// or private
+	Finalize func(string) string
+}
+
+func (n *Namer) Name(input string) string {
+	singular := input
+	var plural string
+	var ok bool
+	if plural, ok = n.Exceptions[singular]; ok {
+		return n.Finalize(plural)
+	}
+	if len(singular) < 2 {
+		return n.Finalize(singular)
+	}
+
+	switch rune(singular[len(singular)-1]) {
+	case 's', 'x', 'z':
+		plural = esPlural(singular)
+	case 'y':
+		sl := rune(singular[len(singular)-2])
+		if isConsonant(sl) {
+			plural = iesPlural(singular)
+		} else {
+			plural = sPlural(singular)
+		}
+	case 'h':
+		sl := rune(singular[len(singular)-2])
+		if sl == 'c' || sl == 's' {
+			plural = esPlural(singular)
+		} else {
+			plural = sPlural(singular)
+		}
+	case 'e':
+		sl := rune(singular[len(singular)-2])
+		if sl == 'f' {
+			plural = vesPlural(singular[:len(singular)-1])
+		} else {
+			plural = sPlural(singular)
+		}
+	case 'f':
+		plural = vesPlural(singular)
+	default:
+		plural = sPlural(singular)
+	}
+	return n.Finalize(plural)
+}
+
+func iesPlural(singular string) string {
+	return singular[:len(singular)-1] + "ies"
+}
+
+func vesPlural(singular string) string {
+	return singular[:len(singular)-1] + "ves"
+}
+
+func esPlural(singular string) string {
+	return singular + "es"
+}
+
+func sPlural(singular string) string {
+	return singular + "s"
+}
+
+func isConsonant(char rune) bool {
+	for _, c := range consonants {
+		if char == c {
+			return true
+		}
+	}
+	return false
+}

--- a/namer/namer.go
+++ b/namer/namer.go
@@ -1,5 +1,5 @@
 /*
-Copyright 2022 The KCP Authors.
+Copyright 2015 The Kubernetes Authors.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
@@ -14,19 +14,28 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
+// This code has been taken from https://github.com/kubernetes/gengo/blob/master/namer/plural_namer.go
+// with minor modifications. The changes are:
+// 1. There is no concept of plublic/private namer here. There is generic namer struct which
+// parses the input and gives us the required plural form.
+// 2. The input argument to function `Name` is customized to accept a string instead of `types.Type`,
+// since we directly modeify the API name in our code-gen.
+
 package namer
 
 var consonants = "bcdfghjklmnpqrstvwxyz"
 
 type Namer struct {
-	// to add any exceptions to look up
+	// use this to add any exceptions to look up
 	Exceptions map[string]string
 	// Use this to either convert everything to lowercase/upper case
 	// or anything else based on whether the parameter will be public
-	// or private
+	// or private.
 	Finalize func(string) string
 }
 
+// Name gives out the final plural names which are
+// to be scaffolded
 func (n *Namer) Name(input string) string {
 	singular := input
 	var plural string

--- a/namer/namer_test.go
+++ b/namer/namer_test.go
@@ -1,0 +1,97 @@
+/*
+Copyright 2022 The KCP Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package namer
+
+import (
+	"testing"
+
+	"github.com/kcp-dev/code-generator/pkg/util"
+)
+
+func TestNamer(t *testing.T) {
+	namer := &Namer{
+		Exceptions: map[string]string{
+			"Blah": "Blah",
+		},
+		Finalize: util.UpperFirst,
+	}
+
+	cases := []struct {
+		typeName string
+		expected string
+	}{
+		{
+			"Pod",
+			"Pods",
+		},
+		{
+			"Entry",
+			"Entries",
+		},
+		{
+			"Fizz",
+			"Fizzes",
+		},
+		{
+			"Blah",
+			"Blah",
+		},
+		{
+			"check",
+			"Checks",
+		},
+		{
+			"Ingress",
+			"Ingresses",
+		},
+		{
+			"ray",
+			"Rays",
+		},
+		{
+			"Fox",
+			"Foxes",
+		},
+		{
+			"City",
+			"Cities",
+		},
+		{
+			"Leaf",
+			"Leaves",
+		},
+		{
+			"Rich",
+			"Riches",
+		},
+		{
+			"Life",
+			"Lives",
+		},
+		{
+			"Myth",
+			"Myths",
+		},
+	}
+
+	for _, c := range cases {
+		output := namer.Name(c.typeName)
+		if output != c.expected {
+			t.Errorf("Unexpected result from namer. Expected %s, got %s", c.expected, output)
+		}
+	}
+}

--- a/pkg/internal/clientgen/parser.go
+++ b/pkg/internal/clientgen/parser.go
@@ -26,6 +26,7 @@ import (
 
 	codegenutil "k8s.io/code-generator/cmd/client-gen/generators/util"
 
+	"github.com/kcp-dev/code-generator/namer"
 	"github.com/kcp-dev/code-generator/pkg/util"
 	gentype "k8s.io/code-generator/cmd/client-gen/types"
 	"sigs.k8s.io/controller-tools/pkg/loader"
@@ -362,6 +363,14 @@ func (a *api) WriteContent() error {
 
 // Execute template and append the contents to the writer.
 func templateExecute(templateName string, data api) error {
+	namer := namer.Namer{
+		Finalize: util.UpperFirst,
+	}
+
+	// Add plural naming to the function map based on a custom namer.
+	funcMap["plural"] = func(input string) string {
+		return namer.Name(input)
+	}
 	templ, err := template.New("wrapper").Funcs(funcMap).Parse(templateName)
 	if err != nil {
 		return err

--- a/pkg/internal/clientgen/templates.go
+++ b/pkg/internal/clientgen/templates.go
@@ -133,10 +133,10 @@ func (w *Wrapped{{upperFirst .Name}}{{upperFirst .Version}}) RESTClient() rest.I
 
 const wrapperMethodsTempl = `
 // Wrapped{{upperFirst .PkgName}}{{upperFirst .Version}} contains the wrapped logical cluster and interface.
-func (w *Wrapped{{upperFirst .PkgName}}{{upperFirst .Version}}) {{.Name}}s{{if .IsNamespaced}}(namespace string){{else}}(){{end}} {{.PkgName}}{{.Version}}.{{.Name}}Interface {
+func (w *Wrapped{{upperFirst .PkgName}}{{upperFirst .Version}}) {{.Name|plural}}{{if .IsNamespaced}}(namespace string){{else}}(){{end}} {{.PkgName}}{{.Version}}.{{.Name}}Interface {
 	return &wrapped{{.Name}}{
 		cluster:  w.cluster,
-		delegate: w.delegate.{{.Name}}s{{if .IsNamespaced}}(namespace){{else}}(){{end}},
+		delegate: w.delegate.{{.Name|plural}}{{if .IsNamespaced}}(namespace){{else}}(){{end}},
 	}
 }
 


### PR DESCRIPTION
This PR adds plural formats while defining interfaces which is similar to what code-gen does.

This is blocked on #17 and needs to be rebased after it is merged. Please review only the last 2 commits. 
It is ready for review, but blocked for merging hence converting it to draft.

Fixes: #19