### PR TITLE
ci: fix build root image name

### DIFF
--- a/.ci-operator.yaml
+++ b/.ci-operator.yaml
@@ -1,4 +1,4 @@
 build_root_image:
   namespace: ci
-  name: codegen-build-root
-  tag: "1.18"
+  name: kcp-dev-build-root
+  tag: "1.17"


### PR DESCRIPTION
Has to match https://github.com/openshift/release/blob/e5f739f31a976a2b28ae212fe34ac3d9b5ec0df7/clusters/app.ci/supplemental-ci-images/kcp-dev-build-root.yaml#L8