### PR TITLE
fix: Adding fixes while running client-gen against k8s

### DIFF
--- a/pkg/generators/clientgen/gen.go
+++ b/pkg/generators/clientgen/gen.go
@@ -490,7 +490,7 @@ func (g *Generator) generateSubInterfaces(ctx *genall.GenerationContext) error {
 			}
 
 			if len(byType) == 0 {
-				return nil
+				continue
 			}
 
 			err = pkgmg.WriteContent(&importList)

--- a/pkg/internal/clientgen/parser.go
+++ b/pkg/internal/clientgen/parser.go
@@ -413,7 +413,7 @@ func adjustTemplate(template, verb string) string {
 }
 
 func adjReturnValueInTemplate(template, verb string) string {
-	s := fmt.Sprintf("w.delegate.{{value .Method \"%s\"}}(ctx,", util.UpperFirst(verb))
+	s := fmt.Sprintf("w.delegate.{{default .Method \"%s\"}}(ctx,", util.UpperFirst(verb))
 	index := strings.Index(template, s) + len(s)
 	return string(template[:index]) + " name, " + string(template[index:])
 }

--- a/pkg/internal/clientgen/parser.go
+++ b/pkg/internal/clientgen/parser.go
@@ -365,6 +365,9 @@ func (a *api) WriteContent() error {
 func templateExecute(templateName string, data api) error {
 	namer := namer.Namer{
 		Finalize: util.UpperFirst,
+		Exceptions: map[string]string{
+			"Endpoints": "Endpoints",
+		},
 	}
 
 	// Add plural naming to the function map based on a custom namer.


### PR DESCRIPTION
This has all the minute fixes which I am finding while testing the generators against upstream k8s. Leaving it in draft, till I figure out everything. Will create a PR in the end.