### PR TITLE
fix: Add fixes for running against upstream

### DIFF
--- a/pkg/generators/clientgen/gen.go
+++ b/pkg/generators/clientgen/gen.go
@@ -89,6 +89,9 @@ type Generator struct {
 	// headerText is the header text to be added to generated wrappers.
 	// It is obtained from `--go-header-text` flag.
 	headerText string
+	// clusterclientWrappers contains the content which has the
+	// initial config and wrappers.
+	clusterclientWrappers []byte
 }
 
 // TODO: Store this information in generation context, as other genrators
@@ -274,7 +277,8 @@ func (g *Generator) writeWrappedClientSet() error {
 		outBytes = formattedBytes
 	}
 
-	return util.WriteContent(outBytes, clientSetFilename, filepath.Join(g.outputDir, g.clientsetName))
+	g.clusterclientWrappers = outBytes
+	return nil
 }
 
 func (g *Generator) writeHeader(out io.Writer) error {
@@ -517,7 +521,7 @@ func (g *Generator) generateSubInterfaces(ctx *genall.GenerationContext) error {
 			}
 		}
 	}
-	return nil
+	return util.WriteContent(g.clusterclientWrappers, clientSetFilename, filepath.Join(g.outputDir, g.clientsetName))
 }
 
 func verifyAdditionalMethod(m clientgen.AdditionalMethod) error {

--- a/pkg/generators/clientgen/gen_test.go
+++ b/pkg/generators/clientgen/gen_test.go
@@ -28,42 +28,6 @@ import (
 )
 
 var _ = Describe("Test generator funcs", func() {
-	Describe("Test setting defaults", func() {
-		var (
-			f flag.Flags
-			g *Generator
-		)
-		BeforeEach(func() {
-			f = flag.Flags{}
-			f.InputDir = "."
-			f.ClientsetAPIPath = "examples"
-			f.OutputDir = "."
-			f.GroupVersions = []string{"apps:v1"}
-
-			g = &Generator{}
-		})
-
-		It("should set defaults correctly", func() {
-			err := g.setDefaults(f)
-			Expect(err).NotTo(HaveOccurred())
-			Expect(g.inputDir).To(Equal("."))
-			Expect(g.clientSetAPIPath).To(Equal("examples"))
-			Expect(g.outputDir).To(Equal("."))
-
-			expected := []types.GroupVersions{{
-				PackageName: "apps",
-				Group:       types.Group("apps"),
-				Versions: []types.PackageVersion{
-					{
-						Version: types.Version("v1"),
-						Package: "apps/v1",
-					},
-				},
-			}}
-			Expect(g.groupVersions).To(Equal(expected))
-		})
-	})
-
 	Describe("Test gv", func() {
 		var (
 			f flag.Flags

--- a/pkg/util/util.go
+++ b/pkg/util/util.go
@@ -75,11 +75,7 @@ const (
 // This logic is taken from k8.io/code-generator, but has a change of letting user pass the
 // directory whose pacakge is to be found.
 func CurrentPackage(dir string) (string, bool) {
-	absPath, err := filepath.Abs(dir)
-	if err != nil {
-		return "", false
-	}
-	goModPath, err := getGoModPath(absPath)
+	goModPath, err := getGoModPath(dir)
 	if err != nil {
 		return "", false
 	}


### PR DESCRIPTION
This PR introduces 2 changes:
1. Writing of cluserclient wrappers moved towards the end, after
interface wrappers are generated. This is to consider the case, wherein
the api pacakge provided by the user does not contain genclient markers
at all.
2. Revert `CurrentPacakge` utility, to find the go mod path of the
directory passed instead of considering the abspath.

Fixes: #28 
Signed-off-by: varshaprasad96 <varshaprasad96@gmail.com>