### PR TITLE
Fix doc: testdata -> examples

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,9 +2,20 @@
 
 ### Usage:
 
+```
+code-generator <command> [input-flags]
+```
+
+where `<command>` can be one of:
+- client
+- lister
+- informer
+
+It is possible to run the code generation for multiple components at once `code-generator client,lister,informer [input-flags]`
+
 #### Input flags:
 
-1. `--input-dir` - The directory path where APIs are defined. Make sure that the types are defined in `<inputDir>/pkg/apis/{$GROUP}/{$VERSION}`. For example, if your input apis are defined in `types.go` inside `testdata/pkg/apis/apps/v1/types.go`, the input directory should be specified as `testdata/pkg`. `{$GROUP}/{$VERSION}` is appended in the input path.
+1. `--input-dir` - The directory path where APIs are defined. Make sure that the types are defined in `<inputDir>/pkg/apis/{$GROUP}/{$VERSION}`. For example, if your input apis are defined in `types.go` inside `examples/pkg/apis/apps/v1/types.go`, the input directory should be specified as `examples/pkg`. `{$GROUP}/{$VERSION}` is appended in the input path.
 **Note**: This is the relative path to the input directory where APIs live.
 
 2. `--output-dir` - The directory where output clients are to be generated. It defaults to the `clientset` folder under current working directory.
@@ -15,7 +26,7 @@
 
 4. `--clientset-name` - The name of the generated clientset package. It defaults to `clientset`.
 
-5. `--group-versions` - List of group versions in the format `group:version`. Define multiple groups by specifying the flag again. For example, the inputs can be: 
+5. `--group-versions` - List of group versions in the format `group:version`. Define multiple groups by specifying the flag again. For example, the inputs can be:
     - `--group-version="apps:v1"`
     - `--group-versions="rbac:v1" --group-versions="apps:v1"`
     - `--group-version="rbac:v1,v2"`
@@ -26,10 +37,11 @@ Example:
 To run it locally and see how it works, use the following command:
 
 ```
-go run main.go client --clientset-name clusterclient --go-header-file testdata/header.txt 
-                      --clientset-api-path=github.com/kcp-dev/code-generator/testdata/pkg/generated/clientset/versioned 
-                      --input-dir testdata/pkg/apis 
+mkdir -p testdata/pkg
+go run main.go client,lister,informer --clientset-name clusterclient --go-header-file examples/header.txt \
+                      --clientset-api-path=github.com/kcp-dev/code-generator/examples/pkg/generated/clientset/versioned \
+                      --input-dir examples/pkg/apis \
                       --output-dir testdata/pkg --group-versions example:v1
 ```
 
-will create an output folder in `testdata/pkg/clientset`.
+will create output folders in `testdata/pkg`.

--- a/main.go
+++ b/main.go
@@ -58,7 +58,7 @@ func main() {
 						  --output-dir examples/pkg 
 						  --group-versions example:v1
 		
-		# To generate listers and informers (Yet to be implemented):
+		# To generate listers and informers:
 		code-gen "client,lister,informer" --clientset-name clusterclient --go-header-file examples/header.txt 
 						  --clientset-api-path=github.com/kcp-dev/code-generator/examples/pkg/generated/clientset/versioned 
 						  --input-dir github.com/kcp-dev/code-generator/examples 
@@ -67,7 +67,7 @@ func main() {
 		`,
 		RunE: func(cmd *cobra.Command, args []string) error {
 			if len(args) == 0 {
-				return fmt.Errorf("no arguments provided to the command. Accepted values are clients, informers and listers.")
+				return fmt.Errorf("no arguments provided to the command. Accepted values are client, informer and lister.")
 			}
 
 			// This argument is expected to be of the form


### PR DESCRIPTION
Signed-off-by: Frederic Giloux <fgiloux@redhat.com>

small enhancements to the readme:
- testdata has been moved to examples
- use of "\\" for new lines in commands
- additional commands available besides client: informer, lister

minor changes in main.go
- updated comment
- corrected log message