### PR TITLE
Don't run generation if no types discovered, add some logging

### DIFF
--- a/pkg/generators/listergen/listergen.go
+++ b/pkg/generators/listergen/listergen.go
@@ -31,6 +31,7 @@ import (
 	"github.com/kcp-dev/code-generator/pkg/util"
 	"golang.org/x/tools/go/packages"
 	"k8s.io/code-generator/cmd/client-gen/types"
+	"k8s.io/klog/v2"
 	"sigs.k8s.io/controller-tools/pkg/genall"
 	"sigs.k8s.io/controller-tools/pkg/loader"
 	"sigs.k8s.io/controller-tools/pkg/markers"
@@ -175,6 +176,7 @@ func (g *Generator) generate(ctx *genall.GenerationContext) error {
 					root.AddError(err)
 				}
 
+				klog.Infof("Generating lister for GroupVersionKind %s:%s/%s", gv.Group.String(), version.String(), info.Name)
 				a, err := listergen.NewAPI(root, info, string(version.Version), gv.PackageName, path, !clientgen.IsClusterScoped(info), &outContent)
 				if err != nil {
 					root.AddError(err)
@@ -202,7 +204,7 @@ func (g *Generator) generate(ctx *genall.GenerationContext) error {
 			}
 
 			if len(byType) == 0 {
-				return nil
+				continue
 			}
 
 			for typeName, content := range byType {


### PR DESCRIPTION
This _should_ enable generation for kubernetes types. Example run + output for kubernetes generation below:

```shell
$  ./bin/code-generator informer,lister \
    --clientset-name clusterclient \
    --go-header-file hack/boilerplate/boilerplate.generatego.txt \
    --clientset-api-path k8s.io/client-go/kubernetes \
    --input-dir ../../kubernetes/kubernetes/staging/src/k8s.io/api/ \
    --output-dir ./examples/kubernetes/ \
    --group-versions core:v1 \
    --group-versions admission:v1 \
    --group-versions admission:v1beta1 \
    --group-versions admissionregistration:v1 \
    --group-versions admissionregistration:v1beta1 \
    --group-versions apps:v1 \
    --group-versions apps:v1beta1 \
    --group-versions apps:v1beta2 \
    --group-versions authentication:v1 \
    --group-versions authentication:v1beta1 \
    --group-versions authorization:v1 \
    --group-versions authorization:v1beta1 \
    --group-versions autoscaling:v1 \
    --group-versions autoscaling:v2 \
    --group-versions autoscaling:v2beta1 \
    --group-versions autoscaling:v2beta2 \
    --group-versions batch:v1 \
    --group-versions batch:v1beta1 \
    --group-versions certificates:v1 \
    --group-versions certificates:v1beta1 \
    --group-versions coordination:v1beta1 \
    --group-versions coordination:v1 \
    --group-versions discovery:v1 \
    --group-versions discovery:v1beta1 \
    --group-versions extensions:v1beta1 \
    --group-versions events:v1 \
    --group-versions events:v1beta1 \
    --group-versions imagepolicy:v1alpha1 \
    --group-versions networking:v1 \
    --group-versions networking:v1beta1 \
    --group-versions node:v1 \
    --group-versions node:v1alpha1 \
    --group-versions node:v1beta1 \
    --group-versions policy:v1 \
    --group-versions policy:v1beta1 \
    --group-versions rbac:v1 \
    --group-versions rbac:v1beta1 \
    --group-versions rbac:v1alpha1 \
    --group-versions scheduling:v1alpha1 \
    --group-versions scheduling:v1beta1 \
    --group-versions scheduling:v1 \
    --group-versions scheduling:v1alpha1 \
    --group-versions storage:v1beta1 \
    --group-versions storage:v1beta1 \
    --group-versions storage:v1 \
    --group-versions flowcontrol:v1alpha1 \
    --group-versions flowcontrol:v1beta1 \
    --group-versions flowcontrol:v1beta2 \
    --group-versions apiserverinternal:v1alpha1

W0714 11:29:18.894027 1378417 informergen.go:207] No types discovered for admission:v1, will skip generation for this GroupVersion
W0714 11:29:19.044112 1378417 informergen.go:207] No types discovered for admission:v1beta1, will skip generation for this GroupVersion
I0714 11:29:25.531249 1378417 informergen.go:223] Generating informer factory
I0714 11:29:25.533007 1378417 informergen.go:229] Generating informer factory interfaces
I0714 11:29:25.533221 1378417 informergen.go:234] Generating generic informer
I0714 11:29:25.537617 1378417 informergen.go:244] Generating group interface for coordination
I0714 11:29:25.537975 1378417 informergen.go:251] Generating version interface for coordination:v1beta1
I0714 11:29:25.538236 1378417 informergen.go:257] Generating informer for GVK coordination:v1beta1/Lease
I0714 11:29:25.539196 1378417 informergen.go:251] Generating version interface for coordination:v1
I0714 11:29:25.539468 1378417 informergen.go:257] Generating informer for GVK coordination:v1/Lease
I0714 11:29:25.540215 1378417 informergen.go:244] Generating group interface for discovery
I0714 11:29:25.540688 1378417 informergen.go:251] Generating version interface for discovery:v1
I0714 11:29:25.540926 1378417 informergen.go:257] Generating informer for GVK discovery:v1/EndpointSlice
I0714 11:29:25.541744 1378417 informergen.go:251] Generating version interface for discovery:v1beta1
I0714 11:29:25.542000 1378417 informergen.go:257] Generating informer for GVK discovery:v1beta1/EndpointSlice
I0714 11:29:25.542859 1378417 informergen.go:244] Generating group interface for storage
I0714 11:29:25.543232 1378417 informergen.go:251] Generating version interface for storage:v1beta1
I0714 11:29:25.543597 1378417 informergen.go:257] Generating informer for GVK storage:v1beta1/CSIDriver
I0714 11:29:25.544286 1378417 informergen.go:257] Generating informer for GVK storage:v1beta1/CSINode
I0714 11:29:25.545016 1378417 informergen.go:257] Generating informer for GVK storage:v1beta1/CSIStorageCapacity
I0714 11:29:25.545801 1378417 informergen.go:257] Generating informer for GVK storage:v1beta1/StorageClass
I0714 11:29:25.546504 1378417 informergen.go:257] Generating informer for GVK storage:v1beta1/VolumeAttachment
I0714 11:29:25.547320 1378417 informergen.go:251] Generating version interface for storage:v1
I0714 11:29:25.547746 1378417 informergen.go:257] Generating informer for GVK storage:v1/CSIDriver
I0714 11:29:25.548514 1378417 informergen.go:257] Generating informer for GVK storage:v1/CSINode
I0714 11:29:25.549227 1378417 informergen.go:257] Generating informer for GVK storage:v1/CSIStorageCapacity
I0714 11:29:25.550015 1378417 informergen.go:257] Generating informer for GVK storage:v1/StorageClass
I0714 11:29:25.550774 1378417 informergen.go:257] Generating informer for GVK storage:v1/VolumeAttachment
I0714 11:29:25.551469 1378417 informergen.go:244] Generating group interface for flowcontrol
I0714 11:29:25.551866 1378417 informergen.go:251] Generating version interface for flowcontrol:v1beta2
I0714 11:29:25.552207 1378417 informergen.go:257] Generating informer for GVK flowcontrol:v1beta2/FlowSchema
I0714 11:29:25.553192 1378417 informergen.go:257] Generating informer for GVK flowcontrol:v1beta2/PriorityLevelConfiguration
I0714 11:29:25.553946 1378417 informergen.go:251] Generating version interface for flowcontrol:v1alpha1
I0714 11:29:25.554227 1378417 informergen.go:257] Generating informer for GVK flowcontrol:v1alpha1/FlowSchema
I0714 11:29:25.554936 1378417 informergen.go:257] Generating informer for GVK flowcontrol:v1alpha1/PriorityLevelConfiguration
I0714 11:29:25.555823 1378417 informergen.go:251] Generating version interface for flowcontrol:v1beta1
I0714 11:29:25.556121 1378417 informergen.go:257] Generating informer for GVK flowcontrol:v1beta1/FlowSchema
I0714 11:29:25.556841 1378417 informergen.go:257] Generating informer for GVK flowcontrol:v1beta1/PriorityLevelConfiguration
I0714 11:29:25.557741 1378417 informergen.go:244] Generating group interface for authentication
I0714 11:29:25.558265 1378417 informergen.go:251] Generating version interface for authentication:v1
I0714 11:29:25.558544 1378417 informergen.go:257] Generating informer for GVK authentication:v1/TokenReview
I0714 11:29:25.559321 1378417 informergen.go:251] Generating version interface for authentication:v1beta1
I0714 11:29:25.559566 1378417 informergen.go:257] Generating informer for GVK authentication:v1beta1/TokenReview
I0714 11:29:25.560299 1378417 informergen.go:244] Generating group interface for certificates
I0714 11:29:25.560743 1378417 informergen.go:251] Generating version interface for certificates:v1
I0714 11:29:25.560980 1378417 informergen.go:257] Generating informer for GVK certificates:v1/CertificateSigningRequest
I0714 11:29:25.561702 1378417 informergen.go:251] Generating version interface for certificates:v1beta1
I0714 11:29:25.561933 1378417 informergen.go:257] Generating informer for GVK certificates:v1beta1/CertificateSigningRequest
I0714 11:29:25.562659 1378417 informergen.go:244] Generating group interface for events
I0714 11:29:25.563093 1378417 informergen.go:251] Generating version interface for events:v1
I0714 11:29:25.563432 1378417 informergen.go:257] Generating informer for GVK events:v1/Event
I0714 11:29:25.564553 1378417 informergen.go:251] Generating version interface for events:v1beta1
I0714 11:29:25.564878 1378417 informergen.go:257] Generating informer for GVK events:v1beta1/Event
I0714 11:29:25.565630 1378417 informergen.go:244] Generating group interface for node
I0714 11:29:25.566024 1378417 informergen.go:251] Generating version interface for node:v1
I0714 11:29:25.566271 1378417 informergen.go:257] Generating informer for GVK node:v1/RuntimeClass
I0714 11:29:25.567007 1378417 informergen.go:251] Generating version interface for node:v1alpha1
I0714 11:29:25.567260 1378417 informergen.go:257] Generating informer for GVK node:v1alpha1/RuntimeClass
I0714 11:29:25.567952 1378417 informergen.go:251] Generating version interface for node:v1beta1
I0714 11:29:25.568189 1378417 informergen.go:257] Generating informer for GVK node:v1beta1/RuntimeClass
I0714 11:29:25.568883 1378417 informergen.go:244] Generating group interface for rbac
I0714 11:29:25.569246 1378417 informergen.go:251] Generating version interface for rbac:v1
I0714 11:29:25.569569 1378417 informergen.go:257] Generating informer for GVK rbac:v1/ClusterRole
I0714 11:29:25.570277 1378417 informergen.go:257] Generating informer for GVK rbac:v1/ClusterRoleBinding
I0714 11:29:25.570958 1378417 informergen.go:257] Generating informer for GVK rbac:v1/Role
I0714 11:29:25.571701 1378417 informergen.go:257] Generating informer for GVK rbac:v1/RoleBinding
I0714 11:29:25.572464 1378417 informergen.go:251] Generating version interface for rbac:v1beta1
I0714 11:29:25.572820 1378417 informergen.go:257] Generating informer for GVK rbac:v1beta1/ClusterRole
I0714 11:29:25.573514 1378417 informergen.go:257] Generating informer for GVK rbac:v1beta1/ClusterRoleBinding
I0714 11:29:25.574323 1378417 informergen.go:257] Generating informer for GVK rbac:v1beta1/Role
I0714 11:29:25.575065 1378417 informergen.go:257] Generating informer for GVK rbac:v1beta1/RoleBinding
I0714 11:29:25.575813 1378417 informergen.go:251] Generating version interface for rbac:v1alpha1
I0714 11:29:25.576173 1378417 informergen.go:257] Generating informer for GVK rbac:v1alpha1/ClusterRole
I0714 11:29:25.576887 1378417 informergen.go:257] Generating informer for GVK rbac:v1alpha1/ClusterRoleBinding
I0714 11:29:25.577593 1378417 informergen.go:257] Generating informer for GVK rbac:v1alpha1/Role
I0714 11:29:25.578316 1378417 informergen.go:257] Generating informer for GVK rbac:v1alpha1/RoleBinding
I0714 11:29:25.579072 1378417 informergen.go:244] Generating group interface for core
I0714 11:29:25.579400 1378417 informergen.go:251] Generating version interface for core:v1
I0714 11:29:25.580192 1378417 informergen.go:257] Generating informer for GVK core:v1/ComponentStatus
I0714 11:29:25.580907 1378417 informergen.go:257] Generating informer for GVK core:v1/ConfigMap
I0714 11:29:25.581612 1378417 informergen.go:257] Generating informer for GVK core:v1/Endpoints
I0714 11:29:25.582317 1378417 informergen.go:257] Generating informer for GVK core:v1/Event
I0714 11:29:25.583024 1378417 informergen.go:257] Generating informer for GVK core:v1/LimitRange
I0714 11:29:25.583729 1378417 informergen.go:257] Generating informer for GVK core:v1/Namespace
I0714 11:29:25.584491 1378417 informergen.go:257] Generating informer for GVK core:v1/Node
I0714 11:29:25.585286 1378417 informergen.go:257] Generating informer for GVK core:v1/PersistentVolume
I0714 11:29:25.586085 1378417 informergen.go:257] Generating informer for GVK core:v1/PersistentVolumeClaim
I0714 11:29:25.586907 1378417 informergen.go:257] Generating informer for GVK core:v1/Pod
I0714 11:29:25.587646 1378417 informergen.go:257] Generating informer for GVK core:v1/PodTemplate
I0714 11:29:25.588499 1378417 informergen.go:257] Generating informer for GVK core:v1/ReplicationController
I0714 11:29:25.589332 1378417 informergen.go:257] Generating informer for GVK core:v1/ResourceQuota
I0714 11:29:25.590119 1378417 informergen.go:257] Generating informer for GVK core:v1/Secret
I0714 11:29:25.591010 1378417 informergen.go:257] Generating informer for GVK core:v1/Service
I0714 11:29:25.591792 1378417 informergen.go:257] Generating informer for GVK core:v1/ServiceAccount
I0714 11:29:25.592559 1378417 informergen.go:244] Generating group interface for admissionregistration
I0714 11:29:25.592924 1378417 informergen.go:251] Generating version interface for admissionregistration:v1beta1
I0714 11:29:25.593195 1378417 informergen.go:257] Generating informer for GVK admissionregistration:v1beta1/MutatingWebhookConfiguration
I0714 11:29:25.594055 1378417 informergen.go:257] Generating informer for GVK admissionregistration:v1beta1/ValidatingWebhookConfiguration
I0714 11:29:25.594855 1378417 informergen.go:251] Generating version interface for admissionregistration:v1
I0714 11:29:25.595171 1378417 informergen.go:257] Generating informer for GVK admissionregistration:v1/MutatingWebhookConfiguration
I0714 11:29:25.595944 1378417 informergen.go:257] Generating informer for GVK admissionregistration:v1/ValidatingWebhookConfiguration
I0714 11:29:25.596716 1378417 informergen.go:244] Generating group interface for batch
I0714 11:29:25.597035 1378417 informergen.go:251] Generating version interface for batch:v1
I0714 11:29:25.597308 1378417 informergen.go:257] Generating informer for GVK batch:v1/CronJob
I0714 11:29:25.598058 1378417 informergen.go:257] Generating informer for GVK batch:v1/Job
I0714 11:29:25.598783 1378417 informergen.go:251] Generating version interface for batch:v1beta1
I0714 11:29:25.599014 1378417 informergen.go:257] Generating informer for GVK batch:v1beta1/CronJob
I0714 11:29:25.599775 1378417 informergen.go:244] Generating group interface for networking
I0714 11:29:25.600127 1378417 informergen.go:251] Generating version interface for networking:v1beta1
I0714 11:29:25.600420 1378417 informergen.go:257] Generating informer for GVK networking:v1beta1/Ingress
I0714 11:29:25.601168 1378417 informergen.go:257] Generating informer for GVK networking:v1beta1/IngressClass
I0714 11:29:25.601920 1378417 informergen.go:251] Generating version interface for networking:v1
I0714 11:29:25.602222 1378417 informergen.go:257] Generating informer for GVK networking:v1/Ingress
I0714 11:29:25.602924 1378417 informergen.go:257] Generating informer for GVK networking:v1/IngressClass
I0714 11:29:25.603597 1378417 informergen.go:257] Generating informer for GVK networking:v1/NetworkPolicy
I0714 11:29:25.604304 1378417 informergen.go:244] Generating group interface for scheduling
I0714 11:29:25.604664 1378417 informergen.go:251] Generating version interface for scheduling:v1
I0714 11:29:25.604921 1378417 informergen.go:257] Generating informer for GVK scheduling:v1/PriorityClass
I0714 11:29:25.605900 1378417 informergen.go:251] Generating version interface for scheduling:v1alpha1
I0714 11:29:25.606198 1378417 informergen.go:257] Generating informer for GVK scheduling:v1alpha1/PriorityClass
I0714 11:29:25.606993 1378417 informergen.go:251] Generating version interface for scheduling:v1beta1
I0714 11:29:25.607270 1378417 informergen.go:257] Generating informer for GVK scheduling:v1beta1/PriorityClass
I0714 11:29:25.607975 1378417 informergen.go:244] Generating group interface for apps
I0714 11:29:25.608336 1378417 informergen.go:251] Generating version interface for apps:v1
I0714 11:29:25.608695 1378417 informergen.go:257] Generating informer for GVK apps:v1/ControllerRevision
I0714 11:29:25.609414 1378417 informergen.go:257] Generating informer for GVK apps:v1/DaemonSet
I0714 11:29:25.610170 1378417 informergen.go:257] Generating informer for GVK apps:v1/Deployment
I0714 11:29:25.610926 1378417 informergen.go:257] Generating informer for GVK apps:v1/ReplicaSet
I0714 11:29:25.611696 1378417 informergen.go:257] Generating informer for GVK apps:v1/StatefulSet
I0714 11:29:25.612438 1378417 informergen.go:251] Generating version interface for apps:v1beta1
I0714 11:29:25.612741 1378417 informergen.go:257] Generating informer for GVK apps:v1beta1/ControllerRevision
I0714 11:29:25.613508 1378417 informergen.go:257] Generating informer for GVK apps:v1beta1/Deployment
I0714 11:29:25.614224 1378417 informergen.go:257] Generating informer for GVK apps:v1beta1/StatefulSet
I0714 11:29:25.614950 1378417 informergen.go:251] Generating version interface for apps:v1beta2
I0714 11:29:25.615327 1378417 informergen.go:257] Generating informer for GVK apps:v1beta2/ControllerRevision
I0714 11:29:25.616096 1378417 informergen.go:257] Generating informer for GVK apps:v1beta2/DaemonSet
I0714 11:29:25.616930 1378417 informergen.go:257] Generating informer for GVK apps:v1beta2/Deployment
I0714 11:29:25.617647 1378417 informergen.go:257] Generating informer for GVK apps:v1beta2/ReplicaSet
I0714 11:29:25.618365 1378417 informergen.go:257] Generating informer for GVK apps:v1beta2/StatefulSet
I0714 11:29:25.619065 1378417 informergen.go:244] Generating group interface for autoscaling
I0714 11:29:25.619486 1378417 informergen.go:251] Generating version interface for autoscaling:v1
I0714 11:29:25.619715 1378417 informergen.go:257] Generating informer for GVK autoscaling:v1/HorizontalPodAutoscaler
I0714 11:29:25.620472 1378417 informergen.go:251] Generating version interface for autoscaling:v2
I0714 11:29:25.620707 1378417 informergen.go:257] Generating informer for GVK autoscaling:v2/HorizontalPodAutoscaler
I0714 11:29:25.621579 1378417 informergen.go:251] Generating version interface for autoscaling:v2beta1
I0714 11:29:25.621896 1378417 informergen.go:257] Generating informer for GVK autoscaling:v2beta1/HorizontalPodAutoscaler
I0714 11:29:25.622842 1378417 informergen.go:251] Generating version interface for autoscaling:v2beta2
I0714 11:29:25.623104 1378417 informergen.go:257] Generating informer for GVK autoscaling:v2beta2/HorizontalPodAutoscaler
I0714 11:29:25.623918 1378417 informergen.go:244] Generating group interface for imagepolicy
I0714 11:29:25.624246 1378417 informergen.go:251] Generating version interface for imagepolicy:v1alpha1
I0714 11:29:25.624546 1378417 informergen.go:257] Generating informer for GVK imagepolicy:v1alpha1/ImageReview
I0714 11:29:25.625289 1378417 informergen.go:244] Generating group interface for policy
I0714 11:29:25.625622 1378417 informergen.go:251] Generating version interface for policy:v1
I0714 11:29:25.625899 1378417 informergen.go:257] Generating informer for GVK policy:v1/Eviction
I0714 11:29:25.626622 1378417 informergen.go:257] Generating informer for GVK policy:v1/PodDisruptionBudget
I0714 11:29:25.627517 1378417 informergen.go:251] Generating version interface for policy:v1beta1
I0714 11:29:25.627821 1378417 informergen.go:257] Generating informer for GVK policy:v1beta1/Eviction
I0714 11:29:25.628534 1378417 informergen.go:257] Generating informer for GVK policy:v1beta1/PodDisruptionBudget
I0714 11:29:25.629287 1378417 informergen.go:257] Generating informer for GVK policy:v1beta1/PodSecurityPolicy
I0714 11:29:25.630045 1378417 informergen.go:244] Generating group interface for apiserverinternal
I0714 11:29:25.630361 1378417 informergen.go:251] Generating version interface for apiserverinternal:v1alpha1
I0714 11:29:25.630595 1378417 informergen.go:257] Generating informer for GVK apiserverinternal:v1alpha1/StorageVersion
I0714 11:29:25.631298 1378417 informergen.go:244] Generating group interface for authorization
I0714 11:29:25.631613 1378417 informergen.go:251] Generating version interface for authorization:v1
I0714 11:29:25.631938 1378417 informergen.go:257] Generating informer for GVK authorization:v1/LocalSubjectAccessReview
I0714 11:29:25.632748 1378417 informergen.go:257] Generating informer for GVK authorization:v1/SelfSubjectAccessReview
I0714 11:29:25.633508 1378417 informergen.go:257] Generating informer for GVK authorization:v1/SelfSubjectRulesReview
I0714 11:29:25.634202 1378417 informergen.go:257] Generating informer for GVK authorization:v1/SubjectAccessReview
I0714 11:29:25.634953 1378417 informergen.go:251] Generating version interface for authorization:v1beta1
I0714 11:29:25.635294 1378417 informergen.go:257] Generating informer for GVK authorization:v1beta1/LocalSubjectAccessReview
I0714 11:29:25.636083 1378417 informergen.go:257] Generating informer for GVK authorization:v1beta1/SelfSubjectAccessReview
I0714 11:29:25.636828 1378417 informergen.go:257] Generating informer for GVK authorization:v1beta1/SelfSubjectRulesReview
I0714 11:29:25.637601 1378417 informergen.go:257] Generating informer for GVK authorization:v1beta1/SubjectAccessReview
I0714 11:29:25.638380 1378417 informergen.go:244] Generating group interface for extensions
I0714 11:29:25.638792 1378417 informergen.go:251] Generating version interface for extensions:v1beta1
I0714 11:29:25.639224 1378417 informergen.go:257] Generating informer for GVK extensions:v1beta1/DaemonSet
I0714 11:29:25.639998 1378417 informergen.go:257] Generating informer for GVK extensions:v1beta1/Deployment
I0714 11:29:25.640792 1378417 informergen.go:257] Generating informer for GVK extensions:v1beta1/Ingress
I0714 11:29:25.641557 1378417 informergen.go:257] Generating informer for GVK extensions:v1beta1/NetworkPolicy
I0714 11:29:25.642271 1378417 informergen.go:257] Generating informer for GVK extensions:v1beta1/PodSecurityPolicy
I0714 11:29:25.643025 1378417 informergen.go:257] Generating informer for GVK extensions:v1beta1/ReplicaSet
I0714 11:29:25.946745 1378417 listergen.go:179] Generating lister for GroupVersionKind core:v1/PersistentVolume
I0714 11:29:25.947693 1378417 listergen.go:179] Generating lister for GroupVersionKind core:v1/PersistentVolumeClaim
I0714 11:29:25.949156 1378417 listergen.go:179] Generating lister for GroupVersionKind core:v1/Pod
I0714 11:29:25.949927 1378417 listergen.go:179] Generating lister for GroupVersionKind core:v1/PodTemplate
I0714 11:29:25.950771 1378417 listergen.go:179] Generating lister for GroupVersionKind core:v1/ReplicationController
I0714 11:29:25.951645 1378417 listergen.go:179] Generating lister for GroupVersionKind core:v1/Service
I0714 11:29:25.952479 1378417 listergen.go:179] Generating lister for GroupVersionKind core:v1/ServiceAccount
I0714 11:29:25.953479 1378417 listergen.go:179] Generating lister for GroupVersionKind core:v1/Endpoints
I0714 11:29:25.954412 1378417 listergen.go:179] Generating lister for GroupVersionKind core:v1/Node
I0714 11:29:25.955137 1378417 listergen.go:179] Generating lister for GroupVersionKind core:v1/Namespace
I0714 11:29:25.955991 1378417 listergen.go:179] Generating lister for GroupVersionKind core:v1/Event
I0714 11:29:25.956880 1378417 listergen.go:179] Generating lister for GroupVersionKind core:v1/LimitRange
I0714 11:29:25.957849 1378417 listergen.go:179] Generating lister for GroupVersionKind core:v1/ResourceQuota
I0714 11:29:25.958694 1378417 listergen.go:179] Generating lister for GroupVersionKind core:v1/Secret
I0714 11:29:25.959497 1378417 listergen.go:179] Generating lister for GroupVersionKind core:v1/ConfigMap
I0714 11:29:25.960320 1378417 listergen.go:179] Generating lister for GroupVersionKind core:v1/ComponentStatus
I0714 11:29:26.351927 1378417 listergen.go:179] Generating lister for GroupVersionKind admissionregistration:v1/ValidatingWebhookConfiguration
I0714 11:29:26.352697 1378417 listergen.go:179] Generating lister for GroupVersionKind admissionregistration:v1/MutatingWebhookConfiguration
I0714 11:29:26.477550 1378417 listergen.go:179] Generating lister for GroupVersionKind admissionregistration:v1beta1/ValidatingWebhookConfiguration
I0714 11:29:26.478241 1378417 listergen.go:179] Generating lister for GroupVersionKind admissionregistration:v1beta1/MutatingWebhookConfiguration
I0714 11:29:26.623391 1378417 listergen.go:179] Generating lister for GroupVersionKind apps:v1/StatefulSet
I0714 11:29:26.624385 1378417 listergen.go:179] Generating lister for GroupVersionKind apps:v1/Deployment
I0714 11:29:26.625308 1378417 listergen.go:179] Generating lister for GroupVersionKind apps:v1/DaemonSet
I0714 11:29:26.626084 1378417 listergen.go:179] Generating lister for GroupVersionKind apps:v1/ReplicaSet
I0714 11:29:26.626924 1378417 listergen.go:179] Generating lister for GroupVersionKind apps:v1/ControllerRevision
I0714 11:29:26.780574 1378417 listergen.go:179] Generating lister for GroupVersionKind apps:v1beta1/StatefulSet
I0714 11:29:26.781501 1378417 listergen.go:179] Generating lister for GroupVersionKind apps:v1beta1/Deployment
I0714 11:29:26.782310 1378417 listergen.go:179] Generating lister for GroupVersionKind apps:v1beta1/ControllerRevision
I0714 11:29:26.937626 1378417 listergen.go:179] Generating lister for GroupVersionKind apps:v1beta2/StatefulSet
I0714 11:29:26.938821 1378417 listergen.go:179] Generating lister for GroupVersionKind apps:v1beta2/Deployment
I0714 11:29:26.940016 1378417 listergen.go:179] Generating lister for GroupVersionKind apps:v1beta2/DaemonSet
I0714 11:29:26.940913 1378417 listergen.go:179] Generating lister for GroupVersionKind apps:v1beta2/ReplicaSet
I0714 11:29:26.941826 1378417 listergen.go:179] Generating lister for GroupVersionKind apps:v1beta2/ControllerRevision
I0714 11:29:27.072963 1378417 listergen.go:179] Generating lister for GroupVersionKind authentication:v1/TokenReview
I0714 11:29:27.208372 1378417 listergen.go:179] Generating lister for GroupVersionKind authentication:v1beta1/TokenReview
I0714 11:29:27.339784 1378417 listergen.go:179] Generating lister for GroupVersionKind authorization:v1/SubjectAccessReview
I0714 11:29:27.340719 1378417 listergen.go:179] Generating lister for GroupVersionKind authorization:v1/SelfSubjectAccessReview
I0714 11:29:27.341454 1378417 listergen.go:179] Generating lister for GroupVersionKind authorization:v1/LocalSubjectAccessReview
I0714 11:29:27.342274 1378417 listergen.go:179] Generating lister for GroupVersionKind authorization:v1/SelfSubjectRulesReview
I0714 11:29:27.478631 1378417 listergen.go:179] Generating lister for GroupVersionKind authorization:v1beta1/SubjectAccessReview
I0714 11:29:27.479315 1378417 listergen.go:179] Generating lister for GroupVersionKind authorization:v1beta1/SelfSubjectAccessReview
I0714 11:29:27.479952 1378417 listergen.go:179] Generating lister for GroupVersionKind authorization:v1beta1/LocalSubjectAccessReview
I0714 11:29:27.480796 1378417 listergen.go:179] Generating lister for GroupVersionKind authorization:v1beta1/SelfSubjectRulesReview
I0714 11:29:27.627310 1378417 listergen.go:179] Generating lister for GroupVersionKind autoscaling:v1/HorizontalPodAutoscaler
I0714 11:29:27.771645 1378417 listergen.go:179] Generating lister for GroupVersionKind autoscaling:v2/HorizontalPodAutoscaler
I0714 11:29:27.912473 1378417 listergen.go:179] Generating lister for GroupVersionKind autoscaling:v2beta1/HorizontalPodAutoscaler
I0714 11:29:28.050093 1378417 listergen.go:179] Generating lister for GroupVersionKind autoscaling:v2beta2/HorizontalPodAutoscaler
I0714 11:29:28.203901 1378417 listergen.go:179] Generating lister for GroupVersionKind batch:v1/Job
I0714 11:29:28.204795 1378417 listergen.go:179] Generating lister for GroupVersionKind batch:v1/CronJob
I0714 11:29:28.340086 1378417 listergen.go:179] Generating lister for GroupVersionKind batch:v1beta1/CronJob
I0714 11:29:28.471092 1378417 listergen.go:179] Generating lister for GroupVersionKind certificates:v1/CertificateSigningRequest
I0714 11:29:28.600329 1378417 listergen.go:179] Generating lister for GroupVersionKind certificates:v1beta1/CertificateSigningRequest
I0714 11:29:28.728536 1378417 listergen.go:179] Generating lister for GroupVersionKind coordination:v1beta1/Lease
I0714 11:29:28.852961 1378417 listergen.go:179] Generating lister for GroupVersionKind coordination:v1/Lease
I0714 11:29:28.986818 1378417 listergen.go:179] Generating lister for GroupVersionKind discovery:v1/EndpointSlice
I0714 11:29:29.128404 1378417 listergen.go:179] Generating lister for GroupVersionKind discovery:v1beta1/EndpointSlice
I0714 11:29:29.307698 1378417 listergen.go:179] Generating lister for GroupVersionKind extensions:v1beta1/Deployment
I0714 11:29:29.308659 1378417 listergen.go:179] Generating lister for GroupVersionKind extensions:v1beta1/DaemonSet
I0714 11:29:29.309770 1378417 listergen.go:179] Generating lister for GroupVersionKind extensions:v1beta1/Ingress
I0714 11:29:29.310659 1378417 listergen.go:179] Generating lister for GroupVersionKind extensions:v1beta1/ReplicaSet
I0714 11:29:29.311473 1378417 listergen.go:179] Generating lister for GroupVersionKind extensions:v1beta1/PodSecurityPolicy
I0714 11:29:29.312231 1378417 listergen.go:179] Generating lister for GroupVersionKind extensions:v1beta1/NetworkPolicy
I0714 11:29:29.451483 1378417 listergen.go:179] Generating lister for GroupVersionKind events:v1/Event
I0714 11:29:29.591742 1378417 listergen.go:179] Generating lister for GroupVersionKind events:v1beta1/Event
I0714 11:29:29.736010 1378417 listergen.go:179] Generating lister for GroupVersionKind imagepolicy:v1alpha1/ImageReview
I0714 11:29:29.883685 1378417 listergen.go:179] Generating lister for GroupVersionKind networking:v1/NetworkPolicy
I0714 11:29:29.884704 1378417 listergen.go:179] Generating lister for GroupVersionKind networking:v1/Ingress
I0714 11:29:29.885574 1378417 listergen.go:179] Generating lister for GroupVersionKind networking:v1/IngressClass
I0714 11:29:30.067243 1378417 listergen.go:179] Generating lister for GroupVersionKind networking:v1beta1/Ingress
I0714 11:29:30.068228 1378417 listergen.go:179] Generating lister for GroupVersionKind networking:v1beta1/IngressClass
I0714 11:29:30.208709 1378417 listergen.go:179] Generating lister for GroupVersionKind node:v1/RuntimeClass
I0714 11:29:30.364279 1378417 listergen.go:179] Generating lister for GroupVersionKind node:v1alpha1/RuntimeClass
I0714 11:29:30.513437 1378417 listergen.go:179] Generating lister for GroupVersionKind node:v1beta1/RuntimeClass
I0714 11:29:30.657424 1378417 listergen.go:179] Generating lister for GroupVersionKind policy:v1/PodDisruptionBudget
I0714 11:29:30.658487 1378417 listergen.go:179] Generating lister for GroupVersionKind policy:v1/Eviction
I0714 11:29:30.850844 1378417 listergen.go:179] Generating lister for GroupVersionKind policy:v1beta1/PodDisruptionBudget
I0714 11:29:30.852231 1378417 listergen.go:179] Generating lister for GroupVersionKind policy:v1beta1/Eviction
I0714 11:29:30.853549 1378417 listergen.go:179] Generating lister for GroupVersionKind policy:v1beta1/PodSecurityPolicy
I0714 11:29:31.060844 1378417 listergen.go:179] Generating lister for GroupVersionKind rbac:v1/Role
I0714 11:29:31.062462 1378417 listergen.go:179] Generating lister for GroupVersionKind rbac:v1/RoleBinding
I0714 11:29:31.064221 1378417 listergen.go:179] Generating lister for GroupVersionKind rbac:v1/ClusterRole
I0714 11:29:31.065488 1378417 listergen.go:179] Generating lister for GroupVersionKind rbac:v1/ClusterRoleBinding
I0714 11:29:31.242687 1378417 listergen.go:179] Generating lister for GroupVersionKind rbac:v1beta1/Role
I0714 11:29:31.244008 1378417 listergen.go:179] Generating lister for GroupVersionKind rbac:v1beta1/RoleBinding
I0714 11:29:31.245193 1378417 listergen.go:179] Generating lister for GroupVersionKind rbac:v1beta1/ClusterRole
I0714 11:29:31.246127 1378417 listergen.go:179] Generating lister for GroupVersionKind rbac:v1beta1/ClusterRoleBinding
I0714 11:29:31.412118 1378417 listergen.go:179] Generating lister for GroupVersionKind rbac:v1alpha1/Role
I0714 11:29:31.413423 1378417 listergen.go:179] Generating lister for GroupVersionKind rbac:v1alpha1/RoleBinding
I0714 11:29:31.414455 1378417 listergen.go:179] Generating lister for GroupVersionKind rbac:v1alpha1/ClusterRole
I0714 11:29:31.415227 1378417 listergen.go:179] Generating lister for GroupVersionKind rbac:v1alpha1/ClusterRoleBinding
I0714 11:29:31.566057 1378417 listergen.go:179] Generating lister for GroupVersionKind scheduling:v1alpha1/PriorityClass
I0714 11:29:31.716464 1378417 listergen.go:179] Generating lister for GroupVersionKind scheduling:v1beta1/PriorityClass
I0714 11:29:31.854491 1378417 listergen.go:179] Generating lister for GroupVersionKind scheduling:v1/PriorityClass
I0714 11:29:32.149172 1378417 listergen.go:179] Generating lister for GroupVersionKind storage:v1beta1/StorageClass
I0714 11:29:32.149887 1378417 listergen.go:179] Generating lister for GroupVersionKind storage:v1beta1/VolumeAttachment
I0714 11:29:32.150646 1378417 listergen.go:179] Generating lister for GroupVersionKind storage:v1beta1/CSIDriver
I0714 11:29:32.151386 1378417 listergen.go:179] Generating lister for GroupVersionKind storage:v1beta1/CSINode
I0714 11:29:32.152061 1378417 listergen.go:179] Generating lister for GroupVersionKind storage:v1beta1/CSIStorageCapacity
I0714 11:29:32.464769 1378417 listergen.go:179] Generating lister for GroupVersionKind storage:v1/StorageClass
I0714 11:29:32.465622 1378417 listergen.go:179] Generating lister for GroupVersionKind storage:v1/VolumeAttachment
I0714 11:29:32.466396 1378417 listergen.go:179] Generating lister for GroupVersionKind storage:v1/CSIDriver
I0714 11:29:32.467076 1378417 listergen.go:179] Generating lister for GroupVersionKind storage:v1/CSINode
I0714 11:29:32.467759 1378417 listergen.go:179] Generating lister for GroupVersionKind storage:v1/CSIStorageCapacity
I0714 11:29:32.609575 1378417 listergen.go:179] Generating lister for GroupVersionKind flowcontrol:v1alpha1/FlowSchema
I0714 11:29:32.610330 1378417 listergen.go:179] Generating lister for GroupVersionKind flowcontrol:v1alpha1/PriorityLevelConfiguration
I0714 11:29:32.744627 1378417 listergen.go:179] Generating lister for GroupVersionKind flowcontrol:v1beta1/FlowSchema
I0714 11:29:32.745384 1378417 listergen.go:179] Generating lister for GroupVersionKind flowcontrol:v1beta1/PriorityLevelConfiguration
I0714 11:29:32.879640 1378417 listergen.go:179] Generating lister for GroupVersionKind flowcontrol:v1beta2/FlowSchema
I0714 11:29:32.880498 1378417 listergen.go:179] Generating lister for GroupVersionKind flowcontrol:v1beta2/PriorityLevelConfiguration
I0714 11:29:33.011586 1378417 listergen.go:179] Generating lister for GroupVersionKind apiserverinternal:v1alpha1/StorageVersion

```