### PR TITLE
:bug: clientgen: use a singular kind name in interface

### DIFF
--- a/examples/pkg/kcp/clients/clientset/versioned/typed/example/v1/clustertesttype.go
+++ b/examples/pkg/kcp/clients/clientset/versioned/typed/example/v1/clustertesttype.go
@@ -34,15 +34,15 @@ import (
 	examplev1client "acme.corp/pkg/generated/clientset/versioned/typed/example/v1"
 )
 
-// ClusterTestTypesClusterGetter has a method to return a ClusterTestTypesClusterInterface.
+// ClusterTestTypesClusterGetter has a method to return a ClusterTestTypeClusterInterface.
 // A group's cluster client should implement this interface.
 type ClusterTestTypesClusterGetter interface {
-	ClusterTestTypes() ClusterTestTypesClusterInterface
+	ClusterTestTypes() ClusterTestTypeClusterInterface
 }
 
-// ClusterTestTypesClusterInterface can operate on ClusterTestTypes across all clusters,
+// ClusterTestTypeClusterInterface can operate on ClusterTestTypes across all clusters,
 // or scope down to one cluster and return a examplev1client.ClusterTestTypeInterface.
-type ClusterTestTypesClusterInterface interface {
+type ClusterTestTypeClusterInterface interface {
 	Cluster(logicalcluster.Name) examplev1client.ClusterTestTypeInterface
 	List(ctx context.Context, opts metav1.ListOptions) (*examplev1.ClusterTestTypeList, error)
 	Watch(ctx context.Context, opts metav1.ListOptions) (watch.Interface, error)

--- a/examples/pkg/kcp/clients/clientset/versioned/typed/example/v1/testtype.go
+++ b/examples/pkg/kcp/clients/clientset/versioned/typed/example/v1/testtype.go
@@ -34,15 +34,15 @@ import (
 	examplev1client "acme.corp/pkg/generated/clientset/versioned/typed/example/v1"
 )
 
-// TestTypesClusterGetter has a method to return a TestTypesClusterInterface.
+// TestTypesClusterGetter has a method to return a TestTypeClusterInterface.
 // A group's cluster client should implement this interface.
 type TestTypesClusterGetter interface {
-	TestTypes() TestTypesClusterInterface
+	TestTypes() TestTypeClusterInterface
 }
 
-// TestTypesClusterInterface can operate on TestTypes across all clusters,
+// TestTypeClusterInterface can operate on TestTypes across all clusters,
 // or scope down to one cluster and return a TestTypesNamespacer.
-type TestTypesClusterInterface interface {
+type TestTypeClusterInterface interface {
 	Cluster(logicalcluster.Name) TestTypesNamespacer
 	List(ctx context.Context, opts metav1.ListOptions) (*examplev1.TestTypeList, error)
 	Watch(ctx context.Context, opts metav1.ListOptions) (watch.Interface, error)

--- a/examples/pkg/kcp/clients/clientset/versioned/typed/example/v1alpha1/clustertesttype.go
+++ b/examples/pkg/kcp/clients/clientset/versioned/typed/example/v1alpha1/clustertesttype.go
@@ -34,15 +34,15 @@ import (
 	examplev1alpha1client "acme.corp/pkg/generated/clientset/versioned/typed/example/v1alpha1"
 )
 
-// ClusterTestTypesClusterGetter has a method to return a ClusterTestTypesClusterInterface.
+// ClusterTestTypesClusterGetter has a method to return a ClusterTestTypeClusterInterface.
 // A group's cluster client should implement this interface.
 type ClusterTestTypesClusterGetter interface {
-	ClusterTestTypes() ClusterTestTypesClusterInterface
+	ClusterTestTypes() ClusterTestTypeClusterInterface
 }
 
-// ClusterTestTypesClusterInterface can operate on ClusterTestTypes across all clusters,
+// ClusterTestTypeClusterInterface can operate on ClusterTestTypes across all clusters,
 // or scope down to one cluster and return a examplev1alpha1client.ClusterTestTypeInterface.
-type ClusterTestTypesClusterInterface interface {
+type ClusterTestTypeClusterInterface interface {
 	Cluster(logicalcluster.Name) examplev1alpha1client.ClusterTestTypeInterface
 	List(ctx context.Context, opts metav1.ListOptions) (*examplev1alpha1.ClusterTestTypeList, error)
 	Watch(ctx context.Context, opts metav1.ListOptions) (watch.Interface, error)

--- a/examples/pkg/kcp/clients/clientset/versioned/typed/example/v1alpha1/testtype.go
+++ b/examples/pkg/kcp/clients/clientset/versioned/typed/example/v1alpha1/testtype.go
@@ -34,15 +34,15 @@ import (
 	examplev1alpha1client "acme.corp/pkg/generated/clientset/versioned/typed/example/v1alpha1"
 )
 
-// TestTypesClusterGetter has a method to return a TestTypesClusterInterface.
+// TestTypesClusterGetter has a method to return a TestTypeClusterInterface.
 // A group's cluster client should implement this interface.
 type TestTypesClusterGetter interface {
-	TestTypes() TestTypesClusterInterface
+	TestTypes() TestTypeClusterInterface
 }
 
-// TestTypesClusterInterface can operate on TestTypes across all clusters,
+// TestTypeClusterInterface can operate on TestTypes across all clusters,
 // or scope down to one cluster and return a TestTypesNamespacer.
-type TestTypesClusterInterface interface {
+type TestTypeClusterInterface interface {
 	Cluster(logicalcluster.Name) TestTypesNamespacer
 	List(ctx context.Context, opts metav1.ListOptions) (*examplev1alpha1.TestTypeList, error)
 	Watch(ctx context.Context, opts metav1.ListOptions) (watch.Interface, error)

--- a/examples/pkg/kcp/clients/clientset/versioned/typed/example/v1beta1/clustertesttype.go
+++ b/examples/pkg/kcp/clients/clientset/versioned/typed/example/v1beta1/clustertesttype.go
@@ -34,15 +34,15 @@ import (
 	examplev1beta1client "acme.corp/pkg/generated/clientset/versioned/typed/example/v1beta1"
 )
 
-// ClusterTestTypesClusterGetter has a method to return a ClusterTestTypesClusterInterface.
+// ClusterTestTypesClusterGetter has a method to return a ClusterTestTypeClusterInterface.
 // A group's cluster client should implement this interface.
 type ClusterTestTypesClusterGetter interface {
-	ClusterTestTypes() ClusterTestTypesClusterInterface
+	ClusterTestTypes() ClusterTestTypeClusterInterface
 }
 
-// ClusterTestTypesClusterInterface can operate on ClusterTestTypes across all clusters,
+// ClusterTestTypeClusterInterface can operate on ClusterTestTypes across all clusters,
 // or scope down to one cluster and return a examplev1beta1client.ClusterTestTypeInterface.
-type ClusterTestTypesClusterInterface interface {
+type ClusterTestTypeClusterInterface interface {
 	Cluster(logicalcluster.Name) examplev1beta1client.ClusterTestTypeInterface
 	List(ctx context.Context, opts metav1.ListOptions) (*examplev1beta1.ClusterTestTypeList, error)
 	Watch(ctx context.Context, opts metav1.ListOptions) (watch.Interface, error)

--- a/examples/pkg/kcp/clients/clientset/versioned/typed/example/v1beta1/testtype.go
+++ b/examples/pkg/kcp/clients/clientset/versioned/typed/example/v1beta1/testtype.go
@@ -28,14 +28,14 @@ import (
 	examplev1beta1client "acme.corp/pkg/generated/clientset/versioned/typed/example/v1beta1"
 )
 
-// TestTypesClusterGetter has a method to return a TestTypesClusterInterface.
+// TestTypesClusterGetter has a method to return a TestTypeClusterInterface.
 // A group's cluster client should implement this interface.
 type TestTypesClusterGetter interface {
-	TestTypes() TestTypesClusterInterface
+	TestTypes() TestTypeClusterInterface
 }
 
-// TestTypesClusterInterface can scope down to one cluster and return a TestTypesNamespacer.
-type TestTypesClusterInterface interface {
+// TestTypeClusterInterface can scope down to one cluster and return a TestTypesNamespacer.
+type TestTypeClusterInterface interface {
 	Cluster(logicalcluster.Name) TestTypesNamespacer
 }
 

--- a/examples/pkg/kcp/clients/clientset/versioned/typed/example/v2/clustertesttype.go
+++ b/examples/pkg/kcp/clients/clientset/versioned/typed/example/v2/clustertesttype.go
@@ -34,15 +34,15 @@ import (
 	examplev2client "acme.corp/pkg/generated/clientset/versioned/typed/example/v2"
 )
 
-// ClusterTestTypesClusterGetter has a method to return a ClusterTestTypesClusterInterface.
+// ClusterTestTypesClusterGetter has a method to return a ClusterTestTypeClusterInterface.
 // A group's cluster client should implement this interface.
 type ClusterTestTypesClusterGetter interface {
-	ClusterTestTypes() ClusterTestTypesClusterInterface
+	ClusterTestTypes() ClusterTestTypeClusterInterface
 }
 
-// ClusterTestTypesClusterInterface can operate on ClusterTestTypes across all clusters,
+// ClusterTestTypeClusterInterface can operate on ClusterTestTypes across all clusters,
 // or scope down to one cluster and return a examplev2client.ClusterTestTypeInterface.
-type ClusterTestTypesClusterInterface interface {
+type ClusterTestTypeClusterInterface interface {
 	Cluster(logicalcluster.Name) examplev2client.ClusterTestTypeInterface
 	List(ctx context.Context, opts metav1.ListOptions) (*examplev2.ClusterTestTypeList, error)
 	Watch(ctx context.Context, opts metav1.ListOptions) (watch.Interface, error)

--- a/examples/pkg/kcp/clients/clientset/versioned/typed/example/v2/testtype.go
+++ b/examples/pkg/kcp/clients/clientset/versioned/typed/example/v2/testtype.go
@@ -34,15 +34,15 @@ import (
 	examplev2client "acme.corp/pkg/generated/clientset/versioned/typed/example/v2"
 )
 
-// TestTypesClusterGetter has a method to return a TestTypesClusterInterface.
+// TestTypesClusterGetter has a method to return a TestTypeClusterInterface.
 // A group's cluster client should implement this interface.
 type TestTypesClusterGetter interface {
-	TestTypes() TestTypesClusterInterface
+	TestTypes() TestTypeClusterInterface
 }
 
-// TestTypesClusterInterface can operate on TestTypes across all clusters,
+// TestTypeClusterInterface can operate on TestTypes across all clusters,
 // or scope down to one cluster and return a TestTypesNamespacer.
-type TestTypesClusterInterface interface {
+type TestTypeClusterInterface interface {
 	Cluster(logicalcluster.Name) TestTypesNamespacer
 	List(ctx context.Context, opts metav1.ListOptions) (*examplev2.TestTypeList, error)
 	Watch(ctx context.Context, opts metav1.ListOptions) (watch.Interface, error)

--- a/examples/pkg/kcp/clients/clientset/versioned/typed/example3/v1/clustertesttype.go
+++ b/examples/pkg/kcp/clients/clientset/versioned/typed/example3/v1/clustertesttype.go
@@ -34,15 +34,15 @@ import (
 	example3v1client "acme.corp/pkg/generated/clientset/versioned/typed/example3/v1"
 )
 
-// ClusterTestTypesClusterGetter has a method to return a ClusterTestTypesClusterInterface.
+// ClusterTestTypesClusterGetter has a method to return a ClusterTestTypeClusterInterface.
 // A group's cluster client should implement this interface.
 type ClusterTestTypesClusterGetter interface {
-	ClusterTestTypes() ClusterTestTypesClusterInterface
+	ClusterTestTypes() ClusterTestTypeClusterInterface
 }
 
-// ClusterTestTypesClusterInterface can operate on ClusterTestTypes across all clusters,
+// ClusterTestTypeClusterInterface can operate on ClusterTestTypes across all clusters,
 // or scope down to one cluster and return a example3v1client.ClusterTestTypeInterface.
-type ClusterTestTypesClusterInterface interface {
+type ClusterTestTypeClusterInterface interface {
 	Cluster(logicalcluster.Name) example3v1client.ClusterTestTypeInterface
 	List(ctx context.Context, opts metav1.ListOptions) (*example3v1.ClusterTestTypeList, error)
 	Watch(ctx context.Context, opts metav1.ListOptions) (watch.Interface, error)

--- a/examples/pkg/kcp/clients/clientset/versioned/typed/example3/v1/testtype.go
+++ b/examples/pkg/kcp/clients/clientset/versioned/typed/example3/v1/testtype.go
@@ -34,15 +34,15 @@ import (
 	example3v1client "acme.corp/pkg/generated/clientset/versioned/typed/example3/v1"
 )
 
-// TestTypesClusterGetter has a method to return a TestTypesClusterInterface.
+// TestTypesClusterGetter has a method to return a TestTypeClusterInterface.
 // A group's cluster client should implement this interface.
 type TestTypesClusterGetter interface {
-	TestTypes() TestTypesClusterInterface
+	TestTypes() TestTypeClusterInterface
 }
 
-// TestTypesClusterInterface can operate on TestTypes across all clusters,
+// TestTypeClusterInterface can operate on TestTypes across all clusters,
 // or scope down to one cluster and return a TestTypesNamespacer.
-type TestTypesClusterInterface interface {
+type TestTypeClusterInterface interface {
 	Cluster(logicalcluster.Name) TestTypesNamespacer
 	List(ctx context.Context, opts metav1.ListOptions) (*example3v1.TestTypeList, error)
 	Watch(ctx context.Context, opts metav1.ListOptions) (watch.Interface, error)

--- a/examples/pkg/kcp/clients/clientset/versioned/typed/existinginterfaces/v1/clustertesttype.go
+++ b/examples/pkg/kcp/clients/clientset/versioned/typed/existinginterfaces/v1/clustertesttype.go
@@ -34,15 +34,15 @@ import (
 	existinginterfacesv1client "acme.corp/pkg/generated/clientset/versioned/typed/existinginterfaces/v1"
 )
 
-// ClusterTestTypesClusterGetter has a method to return a ClusterTestTypesClusterInterface.
+// ClusterTestTypesClusterGetter has a method to return a ClusterTestTypeClusterInterface.
 // A group's cluster client should implement this interface.
 type ClusterTestTypesClusterGetter interface {
-	ClusterTestTypes() ClusterTestTypesClusterInterface
+	ClusterTestTypes() ClusterTestTypeClusterInterface
 }
 
-// ClusterTestTypesClusterInterface can operate on ClusterTestTypes across all clusters,
+// ClusterTestTypeClusterInterface can operate on ClusterTestTypes across all clusters,
 // or scope down to one cluster and return a existinginterfacesv1client.ClusterTestTypeInterface.
-type ClusterTestTypesClusterInterface interface {
+type ClusterTestTypeClusterInterface interface {
 	Cluster(logicalcluster.Name) existinginterfacesv1client.ClusterTestTypeInterface
 	List(ctx context.Context, opts metav1.ListOptions) (*existinginterfacesv1.ClusterTestTypeList, error)
 	Watch(ctx context.Context, opts metav1.ListOptions) (watch.Interface, error)

--- a/examples/pkg/kcp/clients/clientset/versioned/typed/existinginterfaces/v1/testtype.go
+++ b/examples/pkg/kcp/clients/clientset/versioned/typed/existinginterfaces/v1/testtype.go
@@ -34,15 +34,15 @@ import (
 	existinginterfacesv1client "acme.corp/pkg/generated/clientset/versioned/typed/existinginterfaces/v1"
 )
 
-// TestTypesClusterGetter has a method to return a TestTypesClusterInterface.
+// TestTypesClusterGetter has a method to return a TestTypeClusterInterface.
 // A group's cluster client should implement this interface.
 type TestTypesClusterGetter interface {
-	TestTypes() TestTypesClusterInterface
+	TestTypes() TestTypeClusterInterface
 }
 
-// TestTypesClusterInterface can operate on TestTypes across all clusters,
+// TestTypeClusterInterface can operate on TestTypes across all clusters,
 // or scope down to one cluster and return a TestTypesNamespacer.
-type TestTypesClusterInterface interface {
+type TestTypeClusterInterface interface {
 	Cluster(logicalcluster.Name) TestTypesNamespacer
 	List(ctx context.Context, opts metav1.ListOptions) (*existinginterfacesv1.TestTypeList, error)
 	Watch(ctx context.Context, opts metav1.ListOptions) (watch.Interface, error)

--- a/examples/pkg/kcp/clients/clientset/versioned/typed/secondexample/v1/clustertesttype.go
+++ b/examples/pkg/kcp/clients/clientset/versioned/typed/secondexample/v1/clustertesttype.go
@@ -34,15 +34,15 @@ import (
 	secondexamplev1client "acme.corp/pkg/generated/clientset/versioned/typed/secondexample/v1"
 )
 
-// ClusterTestTypesClusterGetter has a method to return a ClusterTestTypesClusterInterface.
+// ClusterTestTypesClusterGetter has a method to return a ClusterTestTypeClusterInterface.
 // A group's cluster client should implement this interface.
 type ClusterTestTypesClusterGetter interface {
-	ClusterTestTypes() ClusterTestTypesClusterInterface
+	ClusterTestTypes() ClusterTestTypeClusterInterface
 }
 
-// ClusterTestTypesClusterInterface can operate on ClusterTestTypes across all clusters,
+// ClusterTestTypeClusterInterface can operate on ClusterTestTypes across all clusters,
 // or scope down to one cluster and return a secondexamplev1client.ClusterTestTypeInterface.
-type ClusterTestTypesClusterInterface interface {
+type ClusterTestTypeClusterInterface interface {
 	Cluster(logicalcluster.Name) secondexamplev1client.ClusterTestTypeInterface
 	List(ctx context.Context, opts metav1.ListOptions) (*secondexamplev1.ClusterTestTypeList, error)
 	Watch(ctx context.Context, opts metav1.ListOptions) (watch.Interface, error)

--- a/examples/pkg/kcp/clients/clientset/versioned/typed/secondexample/v1/testtype.go
+++ b/examples/pkg/kcp/clients/clientset/versioned/typed/secondexample/v1/testtype.go
@@ -34,15 +34,15 @@ import (
 	secondexamplev1client "acme.corp/pkg/generated/clientset/versioned/typed/secondexample/v1"
 )
 
-// TestTypesClusterGetter has a method to return a TestTypesClusterInterface.
+// TestTypesClusterGetter has a method to return a TestTypeClusterInterface.
 // A group's cluster client should implement this interface.
 type TestTypesClusterGetter interface {
-	TestTypes() TestTypesClusterInterface
+	TestTypes() TestTypeClusterInterface
 }
 
-// TestTypesClusterInterface can operate on TestTypes across all clusters,
+// TestTypeClusterInterface can operate on TestTypes across all clusters,
 // or scope down to one cluster and return a TestTypesNamespacer.
-type TestTypesClusterInterface interface {
+type TestTypeClusterInterface interface {
 	Cluster(logicalcluster.Name) TestTypesNamespacer
 	List(ctx context.Context, opts metav1.ListOptions) (*secondexamplev1.TestTypeList, error)
 	Watch(ctx context.Context, opts metav1.ListOptions) (watch.Interface, error)

--- a/examples/pkg/kcpexisting/clients/clientset/versioned/typed/example/v1/clustertesttype.go
+++ b/examples/pkg/kcpexisting/clients/clientset/versioned/typed/example/v1/clustertesttype.go
@@ -34,15 +34,15 @@ import (
 	examplev1client "acme.corp/pkg/generated/clientset/versioned/typed/example/v1"
 )
 
-// ClusterTestTypesClusterGetter has a method to return a ClusterTestTypesClusterInterface.
+// ClusterTestTypesClusterGetter has a method to return a ClusterTestTypeClusterInterface.
 // A group's cluster client should implement this interface.
 type ClusterTestTypesClusterGetter interface {
-	ClusterTestTypes() ClusterTestTypesClusterInterface
+	ClusterTestTypes() ClusterTestTypeClusterInterface
 }
 
-// ClusterTestTypesClusterInterface can operate on ClusterTestTypes across all clusters,
+// ClusterTestTypeClusterInterface can operate on ClusterTestTypes across all clusters,
 // or scope down to one cluster and return a examplev1client.ClusterTestTypeInterface.
-type ClusterTestTypesClusterInterface interface {
+type ClusterTestTypeClusterInterface interface {
 	Cluster(logicalcluster.Name) examplev1client.ClusterTestTypeInterface
 	List(ctx context.Context, opts metav1.ListOptions) (*examplev1.ClusterTestTypeList, error)
 	Watch(ctx context.Context, opts metav1.ListOptions) (watch.Interface, error)

--- a/examples/pkg/kcpexisting/clients/clientset/versioned/typed/example/v1/testtype.go
+++ b/examples/pkg/kcpexisting/clients/clientset/versioned/typed/example/v1/testtype.go
@@ -34,15 +34,15 @@ import (
 	examplev1client "acme.corp/pkg/generated/clientset/versioned/typed/example/v1"
 )
 
-// TestTypesClusterGetter has a method to return a TestTypesClusterInterface.
+// TestTypesClusterGetter has a method to return a TestTypeClusterInterface.
 // A group's cluster client should implement this interface.
 type TestTypesClusterGetter interface {
-	TestTypes() TestTypesClusterInterface
+	TestTypes() TestTypeClusterInterface
 }
 
-// TestTypesClusterInterface can operate on TestTypes across all clusters,
+// TestTypeClusterInterface can operate on TestTypes across all clusters,
 // or scope down to one cluster and return a TestTypesNamespacer.
-type TestTypesClusterInterface interface {
+type TestTypeClusterInterface interface {
 	Cluster(logicalcluster.Name) TestTypesNamespacer
 	List(ctx context.Context, opts metav1.ListOptions) (*examplev1.TestTypeList, error)
 	Watch(ctx context.Context, opts metav1.ListOptions) (watch.Interface, error)

--- a/examples/pkg/kcpexisting/clients/clientset/versioned/typed/example/v1alpha1/clustertesttype.go
+++ b/examples/pkg/kcpexisting/clients/clientset/versioned/typed/example/v1alpha1/clustertesttype.go
@@ -34,15 +34,15 @@ import (
 	examplev1alpha1client "acme.corp/pkg/generated/clientset/versioned/typed/example/v1alpha1"
 )
 
-// ClusterTestTypesClusterGetter has a method to return a ClusterTestTypesClusterInterface.
+// ClusterTestTypesClusterGetter has a method to return a ClusterTestTypeClusterInterface.
 // A group's cluster client should implement this interface.
 type ClusterTestTypesClusterGetter interface {
-	ClusterTestTypes() ClusterTestTypesClusterInterface
+	ClusterTestTypes() ClusterTestTypeClusterInterface
 }
 
-// ClusterTestTypesClusterInterface can operate on ClusterTestTypes across all clusters,
+// ClusterTestTypeClusterInterface can operate on ClusterTestTypes across all clusters,
 // or scope down to one cluster and return a examplev1alpha1client.ClusterTestTypeInterface.
-type ClusterTestTypesClusterInterface interface {
+type ClusterTestTypeClusterInterface interface {
 	Cluster(logicalcluster.Name) examplev1alpha1client.ClusterTestTypeInterface
 	List(ctx context.Context, opts metav1.ListOptions) (*examplev1alpha1.ClusterTestTypeList, error)
 	Watch(ctx context.Context, opts metav1.ListOptions) (watch.Interface, error)

--- a/examples/pkg/kcpexisting/clients/clientset/versioned/typed/example/v1alpha1/testtype.go
+++ b/examples/pkg/kcpexisting/clients/clientset/versioned/typed/example/v1alpha1/testtype.go
@@ -34,15 +34,15 @@ import (
 	examplev1alpha1client "acme.corp/pkg/generated/clientset/versioned/typed/example/v1alpha1"
 )
 
-// TestTypesClusterGetter has a method to return a TestTypesClusterInterface.
+// TestTypesClusterGetter has a method to return a TestTypeClusterInterface.
 // A group's cluster client should implement this interface.
 type TestTypesClusterGetter interface {
-	TestTypes() TestTypesClusterInterface
+	TestTypes() TestTypeClusterInterface
 }
 
-// TestTypesClusterInterface can operate on TestTypes across all clusters,
+// TestTypeClusterInterface can operate on TestTypes across all clusters,
 // or scope down to one cluster and return a TestTypesNamespacer.
-type TestTypesClusterInterface interface {
+type TestTypeClusterInterface interface {
 	Cluster(logicalcluster.Name) TestTypesNamespacer
 	List(ctx context.Context, opts metav1.ListOptions) (*examplev1alpha1.TestTypeList, error)
 	Watch(ctx context.Context, opts metav1.ListOptions) (watch.Interface, error)

--- a/examples/pkg/kcpexisting/clients/clientset/versioned/typed/example/v1beta1/clustertesttype.go
+++ b/examples/pkg/kcpexisting/clients/clientset/versioned/typed/example/v1beta1/clustertesttype.go
@@ -34,15 +34,15 @@ import (
 	examplev1beta1client "acme.corp/pkg/generated/clientset/versioned/typed/example/v1beta1"
 )
 
-// ClusterTestTypesClusterGetter has a method to return a ClusterTestTypesClusterInterface.
+// ClusterTestTypesClusterGetter has a method to return a ClusterTestTypeClusterInterface.
 // A group's cluster client should implement this interface.
 type ClusterTestTypesClusterGetter interface {
-	ClusterTestTypes() ClusterTestTypesClusterInterface
+	ClusterTestTypes() ClusterTestTypeClusterInterface
 }
 
-// ClusterTestTypesClusterInterface can operate on ClusterTestTypes across all clusters,
+// ClusterTestTypeClusterInterface can operate on ClusterTestTypes across all clusters,
 // or scope down to one cluster and return a examplev1beta1client.ClusterTestTypeInterface.
-type ClusterTestTypesClusterInterface interface {
+type ClusterTestTypeClusterInterface interface {
 	Cluster(logicalcluster.Name) examplev1beta1client.ClusterTestTypeInterface
 	List(ctx context.Context, opts metav1.ListOptions) (*examplev1beta1.ClusterTestTypeList, error)
 	Watch(ctx context.Context, opts metav1.ListOptions) (watch.Interface, error)

--- a/examples/pkg/kcpexisting/clients/clientset/versioned/typed/example/v1beta1/testtype.go
+++ b/examples/pkg/kcpexisting/clients/clientset/versioned/typed/example/v1beta1/testtype.go
@@ -28,14 +28,14 @@ import (
 	examplev1beta1client "acme.corp/pkg/generated/clientset/versioned/typed/example/v1beta1"
 )
 
-// TestTypesClusterGetter has a method to return a TestTypesClusterInterface.
+// TestTypesClusterGetter has a method to return a TestTypeClusterInterface.
 // A group's cluster client should implement this interface.
 type TestTypesClusterGetter interface {
-	TestTypes() TestTypesClusterInterface
+	TestTypes() TestTypeClusterInterface
 }
 
-// TestTypesClusterInterface can scope down to one cluster and return a TestTypesNamespacer.
-type TestTypesClusterInterface interface {
+// TestTypeClusterInterface can scope down to one cluster and return a TestTypesNamespacer.
+type TestTypeClusterInterface interface {
 	Cluster(logicalcluster.Name) TestTypesNamespacer
 }
 

--- a/examples/pkg/kcpexisting/clients/clientset/versioned/typed/example/v2/clustertesttype.go
+++ b/examples/pkg/kcpexisting/clients/clientset/versioned/typed/example/v2/clustertesttype.go
@@ -34,15 +34,15 @@ import (
 	examplev2client "acme.corp/pkg/generated/clientset/versioned/typed/example/v2"
 )
 
-// ClusterTestTypesClusterGetter has a method to return a ClusterTestTypesClusterInterface.
+// ClusterTestTypesClusterGetter has a method to return a ClusterTestTypeClusterInterface.
 // A group's cluster client should implement this interface.
 type ClusterTestTypesClusterGetter interface {
-	ClusterTestTypes() ClusterTestTypesClusterInterface
+	ClusterTestTypes() ClusterTestTypeClusterInterface
 }
 
-// ClusterTestTypesClusterInterface can operate on ClusterTestTypes across all clusters,
+// ClusterTestTypeClusterInterface can operate on ClusterTestTypes across all clusters,
 // or scope down to one cluster and return a examplev2client.ClusterTestTypeInterface.
-type ClusterTestTypesClusterInterface interface {
+type ClusterTestTypeClusterInterface interface {
 	Cluster(logicalcluster.Name) examplev2client.ClusterTestTypeInterface
 	List(ctx context.Context, opts metav1.ListOptions) (*examplev2.ClusterTestTypeList, error)
 	Watch(ctx context.Context, opts metav1.ListOptions) (watch.Interface, error)

--- a/examples/pkg/kcpexisting/clients/clientset/versioned/typed/example/v2/testtype.go
+++ b/examples/pkg/kcpexisting/clients/clientset/versioned/typed/example/v2/testtype.go
@@ -34,15 +34,15 @@ import (
 	examplev2client "acme.corp/pkg/generated/clientset/versioned/typed/example/v2"
 )
 
-// TestTypesClusterGetter has a method to return a TestTypesClusterInterface.
+// TestTypesClusterGetter has a method to return a TestTypeClusterInterface.
 // A group's cluster client should implement this interface.
 type TestTypesClusterGetter interface {
-	TestTypes() TestTypesClusterInterface
+	TestTypes() TestTypeClusterInterface
 }
 
-// TestTypesClusterInterface can operate on TestTypes across all clusters,
+// TestTypeClusterInterface can operate on TestTypes across all clusters,
 // or scope down to one cluster and return a TestTypesNamespacer.
-type TestTypesClusterInterface interface {
+type TestTypeClusterInterface interface {
 	Cluster(logicalcluster.Name) TestTypesNamespacer
 	List(ctx context.Context, opts metav1.ListOptions) (*examplev2.TestTypeList, error)
 	Watch(ctx context.Context, opts metav1.ListOptions) (watch.Interface, error)

--- a/examples/pkg/kcpexisting/clients/clientset/versioned/typed/example3/v1/clustertesttype.go
+++ b/examples/pkg/kcpexisting/clients/clientset/versioned/typed/example3/v1/clustertesttype.go
@@ -34,15 +34,15 @@ import (
 	example3v1client "acme.corp/pkg/generated/clientset/versioned/typed/example3/v1"
 )
 
-// ClusterTestTypesClusterGetter has a method to return a ClusterTestTypesClusterInterface.
+// ClusterTestTypesClusterGetter has a method to return a ClusterTestTypeClusterInterface.
 // A group's cluster client should implement this interface.
 type ClusterTestTypesClusterGetter interface {
-	ClusterTestTypes() ClusterTestTypesClusterInterface
+	ClusterTestTypes() ClusterTestTypeClusterInterface
 }
 
-// ClusterTestTypesClusterInterface can operate on ClusterTestTypes across all clusters,
+// ClusterTestTypeClusterInterface can operate on ClusterTestTypes across all clusters,
 // or scope down to one cluster and return a example3v1client.ClusterTestTypeInterface.
-type ClusterTestTypesClusterInterface interface {
+type ClusterTestTypeClusterInterface interface {
 	Cluster(logicalcluster.Name) example3v1client.ClusterTestTypeInterface
 	List(ctx context.Context, opts metav1.ListOptions) (*example3v1.ClusterTestTypeList, error)
 	Watch(ctx context.Context, opts metav1.ListOptions) (watch.Interface, error)

--- a/examples/pkg/kcpexisting/clients/clientset/versioned/typed/example3/v1/testtype.go
+++ b/examples/pkg/kcpexisting/clients/clientset/versioned/typed/example3/v1/testtype.go
@@ -34,15 +34,15 @@ import (
 	example3v1client "acme.corp/pkg/generated/clientset/versioned/typed/example3/v1"
 )
 
-// TestTypesClusterGetter has a method to return a TestTypesClusterInterface.
+// TestTypesClusterGetter has a method to return a TestTypeClusterInterface.
 // A group's cluster client should implement this interface.
 type TestTypesClusterGetter interface {
-	TestTypes() TestTypesClusterInterface
+	TestTypes() TestTypeClusterInterface
 }
 
-// TestTypesClusterInterface can operate on TestTypes across all clusters,
+// TestTypeClusterInterface can operate on TestTypes across all clusters,
 // or scope down to one cluster and return a TestTypesNamespacer.
-type TestTypesClusterInterface interface {
+type TestTypeClusterInterface interface {
 	Cluster(logicalcluster.Name) TestTypesNamespacer
 	List(ctx context.Context, opts metav1.ListOptions) (*example3v1.TestTypeList, error)
 	Watch(ctx context.Context, opts metav1.ListOptions) (watch.Interface, error)

--- a/examples/pkg/kcpexisting/clients/clientset/versioned/typed/existinginterfaces/v1/clustertesttype.go
+++ b/examples/pkg/kcpexisting/clients/clientset/versioned/typed/existinginterfaces/v1/clustertesttype.go
@@ -34,15 +34,15 @@ import (
 	existinginterfacesv1client "acme.corp/pkg/generated/clientset/versioned/typed/existinginterfaces/v1"
 )
 
-// ClusterTestTypesClusterGetter has a method to return a ClusterTestTypesClusterInterface.
+// ClusterTestTypesClusterGetter has a method to return a ClusterTestTypeClusterInterface.
 // A group's cluster client should implement this interface.
 type ClusterTestTypesClusterGetter interface {
-	ClusterTestTypes() ClusterTestTypesClusterInterface
+	ClusterTestTypes() ClusterTestTypeClusterInterface
 }
 
-// ClusterTestTypesClusterInterface can operate on ClusterTestTypes across all clusters,
+// ClusterTestTypeClusterInterface can operate on ClusterTestTypes across all clusters,
 // or scope down to one cluster and return a existinginterfacesv1client.ClusterTestTypeInterface.
-type ClusterTestTypesClusterInterface interface {
+type ClusterTestTypeClusterInterface interface {
 	Cluster(logicalcluster.Name) existinginterfacesv1client.ClusterTestTypeInterface
 	List(ctx context.Context, opts metav1.ListOptions) (*existinginterfacesv1.ClusterTestTypeList, error)
 	Watch(ctx context.Context, opts metav1.ListOptions) (watch.Interface, error)

--- a/examples/pkg/kcpexisting/clients/clientset/versioned/typed/existinginterfaces/v1/testtype.go
+++ b/examples/pkg/kcpexisting/clients/clientset/versioned/typed/existinginterfaces/v1/testtype.go
@@ -34,15 +34,15 @@ import (
 	existinginterfacesv1client "acme.corp/pkg/generated/clientset/versioned/typed/existinginterfaces/v1"
 )
 
-// TestTypesClusterGetter has a method to return a TestTypesClusterInterface.
+// TestTypesClusterGetter has a method to return a TestTypeClusterInterface.
 // A group's cluster client should implement this interface.
 type TestTypesClusterGetter interface {
-	TestTypes() TestTypesClusterInterface
+	TestTypes() TestTypeClusterInterface
 }
 
-// TestTypesClusterInterface can operate on TestTypes across all clusters,
+// TestTypeClusterInterface can operate on TestTypes across all clusters,
 // or scope down to one cluster and return a TestTypesNamespacer.
-type TestTypesClusterInterface interface {
+type TestTypeClusterInterface interface {
 	Cluster(logicalcluster.Name) TestTypesNamespacer
 	List(ctx context.Context, opts metav1.ListOptions) (*existinginterfacesv1.TestTypeList, error)
 	Watch(ctx context.Context, opts metav1.ListOptions) (watch.Interface, error)

--- a/examples/pkg/kcpexisting/clients/clientset/versioned/typed/secondexample/v1/clustertesttype.go
+++ b/examples/pkg/kcpexisting/clients/clientset/versioned/typed/secondexample/v1/clustertesttype.go
@@ -34,15 +34,15 @@ import (
 	secondexamplev1client "acme.corp/pkg/generated/clientset/versioned/typed/secondexample/v1"
 )
 
-// ClusterTestTypesClusterGetter has a method to return a ClusterTestTypesClusterInterface.
+// ClusterTestTypesClusterGetter has a method to return a ClusterTestTypeClusterInterface.
 // A group's cluster client should implement this interface.
 type ClusterTestTypesClusterGetter interface {
-	ClusterTestTypes() ClusterTestTypesClusterInterface
+	ClusterTestTypes() ClusterTestTypeClusterInterface
 }
 
-// ClusterTestTypesClusterInterface can operate on ClusterTestTypes across all clusters,
+// ClusterTestTypeClusterInterface can operate on ClusterTestTypes across all clusters,
 // or scope down to one cluster and return a secondexamplev1client.ClusterTestTypeInterface.
-type ClusterTestTypesClusterInterface interface {
+type ClusterTestTypeClusterInterface interface {
 	Cluster(logicalcluster.Name) secondexamplev1client.ClusterTestTypeInterface
 	List(ctx context.Context, opts metav1.ListOptions) (*secondexamplev1.ClusterTestTypeList, error)
 	Watch(ctx context.Context, opts metav1.ListOptions) (watch.Interface, error)

--- a/examples/pkg/kcpexisting/clients/clientset/versioned/typed/secondexample/v1/testtype.go
+++ b/examples/pkg/kcpexisting/clients/clientset/versioned/typed/secondexample/v1/testtype.go
@@ -34,15 +34,15 @@ import (
 	secondexamplev1client "acme.corp/pkg/generated/clientset/versioned/typed/secondexample/v1"
 )
 
-// TestTypesClusterGetter has a method to return a TestTypesClusterInterface.
+// TestTypesClusterGetter has a method to return a TestTypeClusterInterface.
 // A group's cluster client should implement this interface.
 type TestTypesClusterGetter interface {
-	TestTypes() TestTypesClusterInterface
+	TestTypes() TestTypeClusterInterface
 }
 
-// TestTypesClusterInterface can operate on TestTypes across all clusters,
+// TestTypeClusterInterface can operate on TestTypes across all clusters,
 // or scope down to one cluster and return a TestTypesNamespacer.
-type TestTypesClusterInterface interface {
+type TestTypeClusterInterface interface {
 	Cluster(logicalcluster.Name) TestTypesNamespacer
 	List(ctx context.Context, opts metav1.ListOptions) (*secondexamplev1.TestTypeList, error)
 	Watch(ctx context.Context, opts metav1.ListOptions) (watch.Interface, error)

--- a/pkg/internal/clientgen/type.go
+++ b/pkg/internal/clientgen/type.go
@@ -68,19 +68,19 @@ import (
 	{{.group.PackageAlias}}client "{{.singleClusterClientPackagePath}}/typed/{{.group.Group.PackageName}}/{{.group.Version.PackageName}}"
 )
 
-// {{.kind.Plural}}ClusterGetter has a method to return a {{.kind.Plural}}ClusterInterface.
+// {{.kind.Plural}}ClusterGetter has a method to return a {{.kind.String}}ClusterInterface.
 // A group's cluster client should implement this interface.
 type {{.kind.Plural}}ClusterGetter interface {
-	{{.kind.Plural}}() {{.kind.Plural}}ClusterInterface
+	{{.kind.Plural}}() {{.kind.String}}ClusterInterface
 }
 
 {{ if .kind.SupportsListWatch -}}
-// {{.kind.Plural}}ClusterInterface can operate on {{.kind.Plural}} across all clusters,
+// {{.kind.String}}ClusterInterface can operate on {{.kind.Plural}} across all clusters,
 // or scope down to one cluster and return a {{if .kind.IsNamespaced}}{{.kind.Plural}}Namespacer{{else}}{{.group.PackageAlias}}client.{{.kind.String}}Interface{{end}}.
 {{ else -}}
-// {{.kind.Plural}}ClusterInterface can scope down to one cluster and return a {{if .kind.IsNamespaced}}{{.kind.Plural}}Namespacer{{else}}{{.group.PackageAlias}}client.{{.kind.String}}Interface{{end}}.
+// {{.kind.String}}ClusterInterface can scope down to one cluster and return a {{if .kind.IsNamespaced}}{{.kind.Plural}}Namespacer{{else}}{{.group.PackageAlias}}client.{{.kind.String}}Interface{{end}}.
 {{ end -}}
-type {{.kind.Plural}}ClusterInterface interface {
+type {{.kind.String}}ClusterInterface interface {
 	Cluster(logicalcluster.Name) {{if .kind.IsNamespaced}}{{.kind.Plural}}Namespacer{{else}}{{.group.PackageAlias}}client.{{.kind.String}}Interface{{end}} 
 {{- if .kind.SupportsListWatch }}
 	List(ctx context.Context, opts metav1.ListOptions) (*{{.group.PackageAlias}}.{{.kind.String}}List, error)


### PR DESCRIPTION
clientgen: use a singular kind name in interface

Signed-off-by: Steve Kuznetsov <skuznets@redhat.com>

---

examples: update generated code

Signed-off-by: Steve Kuznetsov <skuznets@redhat.com>

---

