### PR TITLE
:sparkles: clientgen: correctly initialize fake

### DIFF
--- a/examples/pkg/kcp/clients/clientset/versioned/fake/clientset.go
+++ b/examples/pkg/kcp/clients/clientset/versioned/fake/clientset.go
@@ -73,7 +73,7 @@ func NewSimpleClientset(objects ...runtime.Object) *ClusterClientset {
 		}
 	}
 
-	cs := &ClusterClientset{tracker: o}
+	cs := &ClusterClientset{Fake: &kcptesting.Fake{}, tracker: o}
 	cs.discovery = &kcpfakediscovery.FakeDiscovery{Fake: cs.Fake, Cluster: logicalcluster.Wildcard}
 	cs.AddReactor("*", "*", kcptesting.ObjectReaction(o))
 	cs.AddWatchReactor("*", kcptesting.WatchReaction(o))

--- a/examples/pkg/kcpexisting/clients/clientset/versioned/fake/clientset.go
+++ b/examples/pkg/kcpexisting/clients/clientset/versioned/fake/clientset.go
@@ -73,7 +73,7 @@ func NewSimpleClientset(objects ...runtime.Object) *ClusterClientset {
 		}
 	}
 
-	cs := &ClusterClientset{tracker: o}
+	cs := &ClusterClientset{Fake: &kcptesting.Fake{}, tracker: o}
 	cs.discovery = &kcpfakediscovery.FakeDiscovery{Fake: cs.Fake, Cluster: logicalcluster.Wildcard}
 	cs.AddReactor("*", "*", kcptesting.ObjectReaction(o))
 	cs.AddWatchReactor("*", kcptesting.WatchReaction(o))

--- a/pkg/internal/clientgen/fake_clientset.go
+++ b/pkg/internal/clientgen/fake_clientset.go
@@ -91,7 +91,7 @@ func NewSimpleClientset(objects ...runtime.Object) *ClusterClientset {
 		}
 	}
 
-	cs := &ClusterClientset{tracker: o}
+	cs := &ClusterClientset{Fake: &kcptesting.Fake{}, tracker: o}
 	cs.discovery = &kcpfakediscovery.FakeDiscovery{Fake: cs.Fake, Cluster: logicalcluster.Wildcard}
 	cs.AddReactor("*", "*", kcptesting.ObjectReaction(o))
 	cs.AddWatchReactor("*", kcptesting.WatchReaction(o))


### PR DESCRIPTION
We need a pointer to this, as it contains a lock and shared state we reference by passing the thing around. We need to initialize it, therefore.

Signed-off-by: Steve Kuznetsov <skuznets@redhat.com>
