### PR TITLE
:sparkles: update fakes, informers

### DIFF
--- a/examples/go.mod
+++ b/examples/go.mod
@@ -5,8 +5,8 @@ go 1.18
 replace acme.corp/pkg => ./pkg
 
 require (
-	github.com/kcp-dev/apimachinery v0.0.0-20221003220612-a61d757411af
-	github.com/kcp-dev/client-go v0.0.0-20221010124000-dcb42f748279
+	github.com/kcp-dev/apimachinery v0.0.0-20221013124826-6a50a2d1c182
+	github.com/kcp-dev/client-go v0.0.0-20221013125607-cac9fbfe7455
 	github.com/kcp-dev/logicalcluster/v2 v2.0.0-alpha.3
 	k8s.io/apimachinery v0.25.2
 	k8s.io/client-go v0.25.2

--- a/examples/go.sum
+++ b/examples/go.sum
@@ -141,8 +141,12 @@ github.com/jstemmer/go-junit-report v0.0.0-20190106144839-af01ea7f8024/go.mod h1
 github.com/jstemmer/go-junit-report v0.9.1/go.mod h1:Brl9GWCQeLvo8nXZwPNNblvFj/XSXhF0NWZEnDohbsk=
 github.com/kcp-dev/apimachinery v0.0.0-20221003220612-a61d757411af h1:NSBpjZ2+830TvwE6AvYOOf0yk5Yq9PLqK8akRtKLF6s=
 github.com/kcp-dev/apimachinery v0.0.0-20221003220612-a61d757411af/go.mod h1:qnvUHkdxOrNzX17yX+z8r81CZEBuFdveNzWqFlwZ55w=
+github.com/kcp-dev/apimachinery v0.0.0-20221013124826-6a50a2d1c182 h1:tnYt/uVOcIZdrWvRR4OpC+0tbJWfhRhknN2xjuC5OE8=
+github.com/kcp-dev/apimachinery v0.0.0-20221013124826-6a50a2d1c182/go.mod h1:qnvUHkdxOrNzX17yX+z8r81CZEBuFdveNzWqFlwZ55w=
 github.com/kcp-dev/client-go v0.0.0-20221010124000-dcb42f748279 h1:3s06opNG4YtGRcivsfPFJ1V44g1wtJU+M+5g3Tur+Pc=
 github.com/kcp-dev/client-go v0.0.0-20221010124000-dcb42f748279/go.mod h1:E/pWNs9gXdW4QbDJhDl6yVWv22AHU+EhSv54EagP96I=
+github.com/kcp-dev/client-go v0.0.0-20221013125607-cac9fbfe7455 h1:4tYJ1Pkjwsv9x+TKRyFizyUTJL4SfbNahPckRyIMD4A=
+github.com/kcp-dev/client-go v0.0.0-20221013125607-cac9fbfe7455/go.mod h1:E/pWNs9gXdW4QbDJhDl6yVWv22AHU+EhSv54EagP96I=
 github.com/kcp-dev/logicalcluster/v2 v2.0.0-alpha.3 h1:+DwIG/loh2nDB9c/FqNvLzFFq/YtBliLxAfw/uWNzyE=
 github.com/kcp-dev/logicalcluster/v2 v2.0.0-alpha.3/go.mod h1:lfWJL764jKFJxZWOGuFuT3PCCLPo6lV5Cl8P7u9T05g=
 github.com/kisielk/errcheck v1.5.0/go.mod h1:pFxgyoBC7bSaBwPgfKdkLd5X25qrDl4LWUI2bnpBCr8=

--- a/examples/pkg/kcp/clients/clientset/versioned/fake/clientset.go
+++ b/examples/pkg/kcp/clients/clientset/versioned/fake/clientset.go
@@ -22,8 +22,6 @@ limitations under the License.
 package fake
 
 import (
-	"fmt"
-
 	"github.com/kcp-dev/logicalcluster/v2"
 
 	kcpfakediscovery "github.com/kcp-dev/client-go/third_party/k8s.io/client-go/discovery/fake"
@@ -63,15 +61,7 @@ import (
 // for a real clientset and is mostly useful in simple unit tests.
 func NewSimpleClientset(objects ...runtime.Object) *ClusterClientset {
 	o := kcptesting.NewObjectTracker(clientscheme.Scheme, clientscheme.Codecs.UniversalDecoder())
-	for _, obj := range objects {
-		metaObj, ok := obj.(logicalcluster.Object)
-		if !ok {
-			panic(fmt.Sprintf("cannot extract logical cluster from %T", obj))
-		}
-		if err := o.Cluster(logicalcluster.From(metaObj)).Add(obj); err != nil {
-			panic(err)
-		}
-	}
+	o.AddAll(objects...)
 
 	cs := &ClusterClientset{Fake: &kcptesting.Fake{}, tracker: o}
 	cs.discovery = &kcpfakediscovery.FakeDiscovery{Fake: cs.Fake, Cluster: logicalcluster.Wildcard}

--- a/examples/pkg/kcp/clients/clientset/versioned/fake/typed/example/v1/clustertesttype.go
+++ b/examples/pkg/kcp/clients/clientset/versioned/fake/typed/example/v1/clustertesttype.go
@@ -41,8 +41,8 @@ import (
 	examplev1client "acme.corp/pkg/generated/clientset/versioned/typed/example/v1"
 )
 
-var clusterTestTypesResource = schema.GroupVersionResource{Group: "example", Version: "V1", Resource: "clustertesttypes"}
-var clusterTestTypesKind = schema.GroupVersionKind{Group: "example", Version: "V1", Kind: "ClusterTestType"}
+var clusterTestTypesResource = schema.GroupVersionResource{Group: "example", Version: "v1", Resource: "clustertesttypes"}
+var clusterTestTypesKind = schema.GroupVersionKind{Group: "example", Version: "v1", Kind: "ClusterTestType"}
 
 type clusterTestTypesClusterClient struct {
 	*kcptesting.Fake

--- a/examples/pkg/kcp/clients/clientset/versioned/fake/typed/example/v1/testtype.go
+++ b/examples/pkg/kcp/clients/clientset/versioned/fake/typed/example/v1/testtype.go
@@ -42,8 +42,8 @@ import (
 	kcpexamplev1 "acme.corp/pkg/kcp/clients/clientset/versioned/typed/example/v1"
 )
 
-var testTypesResource = schema.GroupVersionResource{Group: "example", Version: "V1", Resource: "testtypes"}
-var testTypesKind = schema.GroupVersionKind{Group: "example", Version: "V1", Kind: "TestType"}
+var testTypesResource = schema.GroupVersionResource{Group: "example", Version: "v1", Resource: "testtypes"}
+var testTypesKind = schema.GroupVersionKind{Group: "example", Version: "v1", Kind: "TestType"}
 
 type testTypesClusterClient struct {
 	*kcptesting.Fake

--- a/examples/pkg/kcp/clients/clientset/versioned/fake/typed/example/v1/withoutverbtype.go
+++ b/examples/pkg/kcp/clients/clientset/versioned/fake/typed/example/v1/withoutverbtype.go
@@ -31,8 +31,8 @@ import (
 	kcpexamplev1 "acme.corp/pkg/kcp/clients/clientset/versioned/typed/example/v1"
 )
 
-var withoutVerbTypesResource = schema.GroupVersionResource{Group: "example", Version: "V1", Resource: "withoutverbtypes"}
-var withoutVerbTypesKind = schema.GroupVersionKind{Group: "example", Version: "V1", Kind: "WithoutVerbType"}
+var withoutVerbTypesResource = schema.GroupVersionResource{Group: "example", Version: "v1", Resource: "withoutverbtypes"}
+var withoutVerbTypesKind = schema.GroupVersionKind{Group: "example", Version: "v1", Kind: "WithoutVerbType"}
 
 type withoutVerbTypesClusterClient struct {
 	*kcptesting.Fake

--- a/examples/pkg/kcp/clients/clientset/versioned/fake/typed/example/v1alpha1/clustertesttype.go
+++ b/examples/pkg/kcp/clients/clientset/versioned/fake/typed/example/v1alpha1/clustertesttype.go
@@ -41,8 +41,8 @@ import (
 	examplev1alpha1client "acme.corp/pkg/generated/clientset/versioned/typed/example/v1alpha1"
 )
 
-var clusterTestTypesResource = schema.GroupVersionResource{Group: "example", Version: "V1alpha1", Resource: "clustertesttypes"}
-var clusterTestTypesKind = schema.GroupVersionKind{Group: "example", Version: "V1alpha1", Kind: "ClusterTestType"}
+var clusterTestTypesResource = schema.GroupVersionResource{Group: "example", Version: "v1alpha1", Resource: "clustertesttypes"}
+var clusterTestTypesKind = schema.GroupVersionKind{Group: "example", Version: "v1alpha1", Kind: "ClusterTestType"}
 
 type clusterTestTypesClusterClient struct {
 	*kcptesting.Fake

--- a/examples/pkg/kcp/clients/clientset/versioned/fake/typed/example/v1alpha1/testtype.go
+++ b/examples/pkg/kcp/clients/clientset/versioned/fake/typed/example/v1alpha1/testtype.go
@@ -42,8 +42,8 @@ import (
 	kcpexamplev1alpha1 "acme.corp/pkg/kcp/clients/clientset/versioned/typed/example/v1alpha1"
 )
 
-var testTypesResource = schema.GroupVersionResource{Group: "example", Version: "V1alpha1", Resource: "testtypes"}
-var testTypesKind = schema.GroupVersionKind{Group: "example", Version: "V1alpha1", Kind: "TestType"}
+var testTypesResource = schema.GroupVersionResource{Group: "example", Version: "v1alpha1", Resource: "testtypes"}
+var testTypesKind = schema.GroupVersionKind{Group: "example", Version: "v1alpha1", Kind: "TestType"}
 
 type testTypesClusterClient struct {
 	*kcptesting.Fake

--- a/examples/pkg/kcp/clients/clientset/versioned/fake/typed/example/v1beta1/clustertesttype.go
+++ b/examples/pkg/kcp/clients/clientset/versioned/fake/typed/example/v1beta1/clustertesttype.go
@@ -41,8 +41,8 @@ import (
 	examplev1beta1client "acme.corp/pkg/generated/clientset/versioned/typed/example/v1beta1"
 )
 
-var clusterTestTypesResource = schema.GroupVersionResource{Group: "example", Version: "V1beta1", Resource: "clustertesttypes"}
-var clusterTestTypesKind = schema.GroupVersionKind{Group: "example", Version: "V1beta1", Kind: "ClusterTestType"}
+var clusterTestTypesResource = schema.GroupVersionResource{Group: "example", Version: "v1beta1", Resource: "clustertesttypes"}
+var clusterTestTypesKind = schema.GroupVersionKind{Group: "example", Version: "v1beta1", Kind: "ClusterTestType"}
 
 type clusterTestTypesClusterClient struct {
 	*kcptesting.Fake

--- a/examples/pkg/kcp/clients/clientset/versioned/fake/typed/example/v1beta1/testtype.go
+++ b/examples/pkg/kcp/clients/clientset/versioned/fake/typed/example/v1beta1/testtype.go
@@ -39,8 +39,8 @@ import (
 	kcpexamplev1beta1 "acme.corp/pkg/kcp/clients/clientset/versioned/typed/example/v1beta1"
 )
 
-var testTypesResource = schema.GroupVersionResource{Group: "example", Version: "V1beta1", Resource: "testtypes"}
-var testTypesKind = schema.GroupVersionKind{Group: "example", Version: "V1beta1", Kind: "TestType"}
+var testTypesResource = schema.GroupVersionResource{Group: "example", Version: "v1beta1", Resource: "testtypes"}
+var testTypesKind = schema.GroupVersionKind{Group: "example", Version: "v1beta1", Kind: "TestType"}
 
 type testTypesClusterClient struct {
 	*kcptesting.Fake

--- a/examples/pkg/kcp/clients/clientset/versioned/fake/typed/example/v2/clustertesttype.go
+++ b/examples/pkg/kcp/clients/clientset/versioned/fake/typed/example/v2/clustertesttype.go
@@ -41,8 +41,8 @@ import (
 	examplev2client "acme.corp/pkg/generated/clientset/versioned/typed/example/v2"
 )
 
-var clusterTestTypesResource = schema.GroupVersionResource{Group: "example", Version: "V2", Resource: "clustertesttypes"}
-var clusterTestTypesKind = schema.GroupVersionKind{Group: "example", Version: "V2", Kind: "ClusterTestType"}
+var clusterTestTypesResource = schema.GroupVersionResource{Group: "example", Version: "v2", Resource: "clustertesttypes"}
+var clusterTestTypesKind = schema.GroupVersionKind{Group: "example", Version: "v2", Kind: "ClusterTestType"}
 
 type clusterTestTypesClusterClient struct {
 	*kcptesting.Fake

--- a/examples/pkg/kcp/clients/clientset/versioned/fake/typed/example/v2/testtype.go
+++ b/examples/pkg/kcp/clients/clientset/versioned/fake/typed/example/v2/testtype.go
@@ -42,8 +42,8 @@ import (
 	kcpexamplev2 "acme.corp/pkg/kcp/clients/clientset/versioned/typed/example/v2"
 )
 
-var testTypesResource = schema.GroupVersionResource{Group: "example", Version: "V2", Resource: "testtypes"}
-var testTypesKind = schema.GroupVersionKind{Group: "example", Version: "V2", Kind: "TestType"}
+var testTypesResource = schema.GroupVersionResource{Group: "example", Version: "v2", Resource: "testtypes"}
+var testTypesKind = schema.GroupVersionKind{Group: "example", Version: "v2", Kind: "TestType"}
 
 type testTypesClusterClient struct {
 	*kcptesting.Fake

--- a/examples/pkg/kcp/clients/clientset/versioned/fake/typed/example3/v1/clustertesttype.go
+++ b/examples/pkg/kcp/clients/clientset/versioned/fake/typed/example3/v1/clustertesttype.go
@@ -41,8 +41,8 @@ import (
 	example3v1client "acme.corp/pkg/generated/clientset/versioned/typed/example3/v1"
 )
 
-var clusterTestTypesResource = schema.GroupVersionResource{Group: "example3.some.corp", Version: "V1", Resource: "clustertesttypes"}
-var clusterTestTypesKind = schema.GroupVersionKind{Group: "example3.some.corp", Version: "V1", Kind: "ClusterTestType"}
+var clusterTestTypesResource = schema.GroupVersionResource{Group: "example3.some.corp", Version: "v1", Resource: "clustertesttypes"}
+var clusterTestTypesKind = schema.GroupVersionKind{Group: "example3.some.corp", Version: "v1", Kind: "ClusterTestType"}
 
 type clusterTestTypesClusterClient struct {
 	*kcptesting.Fake

--- a/examples/pkg/kcp/clients/clientset/versioned/fake/typed/example3/v1/testtype.go
+++ b/examples/pkg/kcp/clients/clientset/versioned/fake/typed/example3/v1/testtype.go
@@ -43,8 +43,8 @@ import (
 	kcpexample3v1 "acme.corp/pkg/kcp/clients/clientset/versioned/typed/example3/v1"
 )
 
-var testTypesResource = schema.GroupVersionResource{Group: "example3.some.corp", Version: "V1", Resource: "testtypes"}
-var testTypesKind = schema.GroupVersionKind{Group: "example3.some.corp", Version: "V1", Kind: "TestType"}
+var testTypesResource = schema.GroupVersionResource{Group: "example3.some.corp", Version: "v1", Resource: "testtypes"}
+var testTypesKind = schema.GroupVersionKind{Group: "example3.some.corp", Version: "v1", Kind: "TestType"}
 
 type testTypesClusterClient struct {
 	*kcptesting.Fake

--- a/examples/pkg/kcp/clients/clientset/versioned/fake/typed/existinginterfaces/v1/clustertesttype.go
+++ b/examples/pkg/kcp/clients/clientset/versioned/fake/typed/existinginterfaces/v1/clustertesttype.go
@@ -41,8 +41,8 @@ import (
 	existinginterfacesv1client "acme.corp/pkg/generated/clientset/versioned/typed/existinginterfaces/v1"
 )
 
-var clusterTestTypesResource = schema.GroupVersionResource{Group: "existinginterfaces.acme.corp", Version: "V1", Resource: "clustertesttypes"}
-var clusterTestTypesKind = schema.GroupVersionKind{Group: "existinginterfaces.acme.corp", Version: "V1", Kind: "ClusterTestType"}
+var clusterTestTypesResource = schema.GroupVersionResource{Group: "existinginterfaces.acme.corp", Version: "v1", Resource: "clustertesttypes"}
+var clusterTestTypesKind = schema.GroupVersionKind{Group: "existinginterfaces.acme.corp", Version: "v1", Kind: "ClusterTestType"}
 
 type clusterTestTypesClusterClient struct {
 	*kcptesting.Fake

--- a/examples/pkg/kcp/clients/clientset/versioned/fake/typed/existinginterfaces/v1/testtype.go
+++ b/examples/pkg/kcp/clients/clientset/versioned/fake/typed/existinginterfaces/v1/testtype.go
@@ -42,8 +42,8 @@ import (
 	kcpexistinginterfacesv1 "acme.corp/pkg/kcp/clients/clientset/versioned/typed/existinginterfaces/v1"
 )
 
-var testTypesResource = schema.GroupVersionResource{Group: "existinginterfaces.acme.corp", Version: "V1", Resource: "testtypes"}
-var testTypesKind = schema.GroupVersionKind{Group: "existinginterfaces.acme.corp", Version: "V1", Kind: "TestType"}
+var testTypesResource = schema.GroupVersionResource{Group: "existinginterfaces.acme.corp", Version: "v1", Resource: "testtypes"}
+var testTypesKind = schema.GroupVersionKind{Group: "existinginterfaces.acme.corp", Version: "v1", Kind: "TestType"}
 
 type testTypesClusterClient struct {
 	*kcptesting.Fake

--- a/examples/pkg/kcp/clients/clientset/versioned/fake/typed/secondexample/v1/clustertesttype.go
+++ b/examples/pkg/kcp/clients/clientset/versioned/fake/typed/secondexample/v1/clustertesttype.go
@@ -41,8 +41,8 @@ import (
 	secondexamplev1client "acme.corp/pkg/generated/clientset/versioned/typed/secondexample/v1"
 )
 
-var clusterTestTypesResource = schema.GroupVersionResource{Group: "secondexample", Version: "V1", Resource: "clustertesttypes"}
-var clusterTestTypesKind = schema.GroupVersionKind{Group: "secondexample", Version: "V1", Kind: "ClusterTestType"}
+var clusterTestTypesResource = schema.GroupVersionResource{Group: "secondexample", Version: "v1", Resource: "clustertesttypes"}
+var clusterTestTypesKind = schema.GroupVersionKind{Group: "secondexample", Version: "v1", Kind: "ClusterTestType"}
 
 type clusterTestTypesClusterClient struct {
 	*kcptesting.Fake

--- a/examples/pkg/kcp/clients/clientset/versioned/fake/typed/secondexample/v1/testtype.go
+++ b/examples/pkg/kcp/clients/clientset/versioned/fake/typed/secondexample/v1/testtype.go
@@ -42,8 +42,8 @@ import (
 	kcpsecondexamplev1 "acme.corp/pkg/kcp/clients/clientset/versioned/typed/secondexample/v1"
 )
 
-var testTypesResource = schema.GroupVersionResource{Group: "secondexample", Version: "V1", Resource: "testtypes"}
-var testTypesKind = schema.GroupVersionKind{Group: "secondexample", Version: "V1", Kind: "TestType"}
+var testTypesResource = schema.GroupVersionResource{Group: "secondexample", Version: "v1", Resource: "testtypes"}
+var testTypesKind = schema.GroupVersionKind{Group: "secondexample", Version: "v1", Kind: "TestType"}
 
 type testTypesClusterClient struct {
 	*kcptesting.Fake

--- a/examples/pkg/kcp/clients/informers/example/v1/clustertesttype.go
+++ b/examples/pkg/kcp/clients/informers/example/v1/clustertesttype.go
@@ -42,7 +42,7 @@ import (
 // ClusterTestTypeClusterInformer provides access to a shared informer and lister for
 // ClusterTestTypes.
 type ClusterTestTypeClusterInformer interface {
-	Informer() cache.SharedIndexInformer
+	Informer() kcpcache.ScopeableSharedIndexInformer
 	Lister() examplev1listers.ClusterTestTypeClusterLister
 }
 
@@ -54,14 +54,14 @@ type clusterTestTypeClusterInformer struct {
 // NewClusterTestTypeClusterInformer constructs a new informer for ClusterTestType type.
 // Always prefer using an informer factory to get a shared informer instead of getting an independent
 // one. This reduces memory footprint and number of connections to the server.
-func NewClusterTestTypeClusterInformer(client clientset.ClusterInterface, resyncPeriod time.Duration, indexers cache.Indexers) cache.SharedIndexInformer {
+func NewClusterTestTypeClusterInformer(client clientset.ClusterInterface, resyncPeriod time.Duration, indexers cache.Indexers) kcpcache.ScopeableSharedIndexInformer {
 	return NewFilteredClusterTestTypeClusterInformer(client, resyncPeriod, indexers, nil)
 }
 
 // NewFilteredClusterTestTypeClusterInformer constructs a new informer for ClusterTestType type.
 // Always prefer using an informer factory to get a shared informer instead of getting an independent
 // one. This reduces memory footprint and number of connections to the server.
-func NewFilteredClusterTestTypeClusterInformer(client clientset.ClusterInterface, resyncPeriod time.Duration, indexers cache.Indexers, tweakListOptions internalinterfaces.TweakListOptionsFunc) cache.SharedIndexInformer {
+func NewFilteredClusterTestTypeClusterInformer(client clientset.ClusterInterface, resyncPeriod time.Duration, indexers cache.Indexers, tweakListOptions internalinterfaces.TweakListOptionsFunc) kcpcache.ScopeableSharedIndexInformer {
 	return kcpinformers.NewSharedIndexInformer(
 		&cache.ListWatch{
 			ListFunc: func(options metav1.ListOptions) (runtime.Object, error) {
@@ -83,7 +83,7 @@ func NewFilteredClusterTestTypeClusterInformer(client clientset.ClusterInterface
 	)
 }
 
-func (f *clusterTestTypeClusterInformer) defaultInformer(client clientset.ClusterInterface, resyncPeriod time.Duration) cache.SharedIndexInformer {
+func (f *clusterTestTypeClusterInformer) defaultInformer(client clientset.ClusterInterface, resyncPeriod time.Duration) kcpcache.ScopeableSharedIndexInformer {
 	return NewFilteredClusterTestTypeClusterInformer(client, resyncPeriod, cache.Indexers{
 		kcpcache.ClusterIndexName: kcpcache.ClusterIndexFunc,
 	},
@@ -91,7 +91,7 @@ func (f *clusterTestTypeClusterInformer) defaultInformer(client clientset.Cluste
 	)
 }
 
-func (f *clusterTestTypeClusterInformer) Informer() cache.SharedIndexInformer {
+func (f *clusterTestTypeClusterInformer) Informer() kcpcache.ScopeableSharedIndexInformer {
 	return f.factory.InformerFor(&examplev1.ClusterTestType{}, f.defaultInformer)
 }
 

--- a/examples/pkg/kcp/clients/informers/example/v1/testtype.go
+++ b/examples/pkg/kcp/clients/informers/example/v1/testtype.go
@@ -42,7 +42,7 @@ import (
 // TestTypeClusterInformer provides access to a shared informer and lister for
 // TestTypes.
 type TestTypeClusterInformer interface {
-	Informer() cache.SharedIndexInformer
+	Informer() kcpcache.ScopeableSharedIndexInformer
 	Lister() examplev1listers.TestTypeClusterLister
 }
 
@@ -54,14 +54,14 @@ type testTypeClusterInformer struct {
 // NewTestTypeClusterInformer constructs a new informer for TestType type.
 // Always prefer using an informer factory to get a shared informer instead of getting an independent
 // one. This reduces memory footprint and number of connections to the server.
-func NewTestTypeClusterInformer(client clientset.ClusterInterface, resyncPeriod time.Duration, indexers cache.Indexers) cache.SharedIndexInformer {
+func NewTestTypeClusterInformer(client clientset.ClusterInterface, resyncPeriod time.Duration, indexers cache.Indexers) kcpcache.ScopeableSharedIndexInformer {
 	return NewFilteredTestTypeClusterInformer(client, resyncPeriod, indexers, nil)
 }
 
 // NewFilteredTestTypeClusterInformer constructs a new informer for TestType type.
 // Always prefer using an informer factory to get a shared informer instead of getting an independent
 // one. This reduces memory footprint and number of connections to the server.
-func NewFilteredTestTypeClusterInformer(client clientset.ClusterInterface, resyncPeriod time.Duration, indexers cache.Indexers, tweakListOptions internalinterfaces.TweakListOptionsFunc) cache.SharedIndexInformer {
+func NewFilteredTestTypeClusterInformer(client clientset.ClusterInterface, resyncPeriod time.Duration, indexers cache.Indexers, tweakListOptions internalinterfaces.TweakListOptionsFunc) kcpcache.ScopeableSharedIndexInformer {
 	return kcpinformers.NewSharedIndexInformer(
 		&cache.ListWatch{
 			ListFunc: func(options metav1.ListOptions) (runtime.Object, error) {
@@ -83,7 +83,7 @@ func NewFilteredTestTypeClusterInformer(client clientset.ClusterInterface, resyn
 	)
 }
 
-func (f *testTypeClusterInformer) defaultInformer(client clientset.ClusterInterface, resyncPeriod time.Duration) cache.SharedIndexInformer {
+func (f *testTypeClusterInformer) defaultInformer(client clientset.ClusterInterface, resyncPeriod time.Duration) kcpcache.ScopeableSharedIndexInformer {
 	return NewFilteredTestTypeClusterInformer(client, resyncPeriod, cache.Indexers{
 		kcpcache.ClusterIndexName:             kcpcache.ClusterIndexFunc,
 		kcpcache.ClusterAndNamespaceIndexName: kcpcache.ClusterAndNamespaceIndexFunc},
@@ -91,7 +91,7 @@ func (f *testTypeClusterInformer) defaultInformer(client clientset.ClusterInterf
 	)
 }
 
-func (f *testTypeClusterInformer) Informer() cache.SharedIndexInformer {
+func (f *testTypeClusterInformer) Informer() kcpcache.ScopeableSharedIndexInformer {
 	return f.factory.InformerFor(&examplev1.TestType{}, f.defaultInformer)
 }
 

--- a/examples/pkg/kcp/clients/informers/example/v1alpha1/clustertesttype.go
+++ b/examples/pkg/kcp/clients/informers/example/v1alpha1/clustertesttype.go
@@ -42,7 +42,7 @@ import (
 // ClusterTestTypeClusterInformer provides access to a shared informer and lister for
 // ClusterTestTypes.
 type ClusterTestTypeClusterInformer interface {
-	Informer() cache.SharedIndexInformer
+	Informer() kcpcache.ScopeableSharedIndexInformer
 	Lister() examplev1alpha1listers.ClusterTestTypeClusterLister
 }
 
@@ -54,14 +54,14 @@ type clusterTestTypeClusterInformer struct {
 // NewClusterTestTypeClusterInformer constructs a new informer for ClusterTestType type.
 // Always prefer using an informer factory to get a shared informer instead of getting an independent
 // one. This reduces memory footprint and number of connections to the server.
-func NewClusterTestTypeClusterInformer(client clientset.ClusterInterface, resyncPeriod time.Duration, indexers cache.Indexers) cache.SharedIndexInformer {
+func NewClusterTestTypeClusterInformer(client clientset.ClusterInterface, resyncPeriod time.Duration, indexers cache.Indexers) kcpcache.ScopeableSharedIndexInformer {
 	return NewFilteredClusterTestTypeClusterInformer(client, resyncPeriod, indexers, nil)
 }
 
 // NewFilteredClusterTestTypeClusterInformer constructs a new informer for ClusterTestType type.
 // Always prefer using an informer factory to get a shared informer instead of getting an independent
 // one. This reduces memory footprint and number of connections to the server.
-func NewFilteredClusterTestTypeClusterInformer(client clientset.ClusterInterface, resyncPeriod time.Duration, indexers cache.Indexers, tweakListOptions internalinterfaces.TweakListOptionsFunc) cache.SharedIndexInformer {
+func NewFilteredClusterTestTypeClusterInformer(client clientset.ClusterInterface, resyncPeriod time.Duration, indexers cache.Indexers, tweakListOptions internalinterfaces.TweakListOptionsFunc) kcpcache.ScopeableSharedIndexInformer {
 	return kcpinformers.NewSharedIndexInformer(
 		&cache.ListWatch{
 			ListFunc: func(options metav1.ListOptions) (runtime.Object, error) {
@@ -83,7 +83,7 @@ func NewFilteredClusterTestTypeClusterInformer(client clientset.ClusterInterface
 	)
 }
 
-func (f *clusterTestTypeClusterInformer) defaultInformer(client clientset.ClusterInterface, resyncPeriod time.Duration) cache.SharedIndexInformer {
+func (f *clusterTestTypeClusterInformer) defaultInformer(client clientset.ClusterInterface, resyncPeriod time.Duration) kcpcache.ScopeableSharedIndexInformer {
 	return NewFilteredClusterTestTypeClusterInformer(client, resyncPeriod, cache.Indexers{
 		kcpcache.ClusterIndexName: kcpcache.ClusterIndexFunc,
 	},
@@ -91,7 +91,7 @@ func (f *clusterTestTypeClusterInformer) defaultInformer(client clientset.Cluste
 	)
 }
 
-func (f *clusterTestTypeClusterInformer) Informer() cache.SharedIndexInformer {
+func (f *clusterTestTypeClusterInformer) Informer() kcpcache.ScopeableSharedIndexInformer {
 	return f.factory.InformerFor(&examplev1alpha1.ClusterTestType{}, f.defaultInformer)
 }
 

--- a/examples/pkg/kcp/clients/informers/example/v1alpha1/testtype.go
+++ b/examples/pkg/kcp/clients/informers/example/v1alpha1/testtype.go
@@ -42,7 +42,7 @@ import (
 // TestTypeClusterInformer provides access to a shared informer and lister for
 // TestTypes.
 type TestTypeClusterInformer interface {
-	Informer() cache.SharedIndexInformer
+	Informer() kcpcache.ScopeableSharedIndexInformer
 	Lister() examplev1alpha1listers.TestTypeClusterLister
 }
 
@@ -54,14 +54,14 @@ type testTypeClusterInformer struct {
 // NewTestTypeClusterInformer constructs a new informer for TestType type.
 // Always prefer using an informer factory to get a shared informer instead of getting an independent
 // one. This reduces memory footprint and number of connections to the server.
-func NewTestTypeClusterInformer(client clientset.ClusterInterface, resyncPeriod time.Duration, indexers cache.Indexers) cache.SharedIndexInformer {
+func NewTestTypeClusterInformer(client clientset.ClusterInterface, resyncPeriod time.Duration, indexers cache.Indexers) kcpcache.ScopeableSharedIndexInformer {
 	return NewFilteredTestTypeClusterInformer(client, resyncPeriod, indexers, nil)
 }
 
 // NewFilteredTestTypeClusterInformer constructs a new informer for TestType type.
 // Always prefer using an informer factory to get a shared informer instead of getting an independent
 // one. This reduces memory footprint and number of connections to the server.
-func NewFilteredTestTypeClusterInformer(client clientset.ClusterInterface, resyncPeriod time.Duration, indexers cache.Indexers, tweakListOptions internalinterfaces.TweakListOptionsFunc) cache.SharedIndexInformer {
+func NewFilteredTestTypeClusterInformer(client clientset.ClusterInterface, resyncPeriod time.Duration, indexers cache.Indexers, tweakListOptions internalinterfaces.TweakListOptionsFunc) kcpcache.ScopeableSharedIndexInformer {
 	return kcpinformers.NewSharedIndexInformer(
 		&cache.ListWatch{
 			ListFunc: func(options metav1.ListOptions) (runtime.Object, error) {
@@ -83,7 +83,7 @@ func NewFilteredTestTypeClusterInformer(client clientset.ClusterInterface, resyn
 	)
 }
 
-func (f *testTypeClusterInformer) defaultInformer(client clientset.ClusterInterface, resyncPeriod time.Duration) cache.SharedIndexInformer {
+func (f *testTypeClusterInformer) defaultInformer(client clientset.ClusterInterface, resyncPeriod time.Duration) kcpcache.ScopeableSharedIndexInformer {
 	return NewFilteredTestTypeClusterInformer(client, resyncPeriod, cache.Indexers{
 		kcpcache.ClusterIndexName:             kcpcache.ClusterIndexFunc,
 		kcpcache.ClusterAndNamespaceIndexName: kcpcache.ClusterAndNamespaceIndexFunc},
@@ -91,7 +91,7 @@ func (f *testTypeClusterInformer) defaultInformer(client clientset.ClusterInterf
 	)
 }
 
-func (f *testTypeClusterInformer) Informer() cache.SharedIndexInformer {
+func (f *testTypeClusterInformer) Informer() kcpcache.ScopeableSharedIndexInformer {
 	return f.factory.InformerFor(&examplev1alpha1.TestType{}, f.defaultInformer)
 }
 

--- a/examples/pkg/kcp/clients/informers/example/v1beta1/clustertesttype.go
+++ b/examples/pkg/kcp/clients/informers/example/v1beta1/clustertesttype.go
@@ -42,7 +42,7 @@ import (
 // ClusterTestTypeClusterInformer provides access to a shared informer and lister for
 // ClusterTestTypes.
 type ClusterTestTypeClusterInformer interface {
-	Informer() cache.SharedIndexInformer
+	Informer() kcpcache.ScopeableSharedIndexInformer
 	Lister() examplev1beta1listers.ClusterTestTypeClusterLister
 }
 
@@ -54,14 +54,14 @@ type clusterTestTypeClusterInformer struct {
 // NewClusterTestTypeClusterInformer constructs a new informer for ClusterTestType type.
 // Always prefer using an informer factory to get a shared informer instead of getting an independent
 // one. This reduces memory footprint and number of connections to the server.
-func NewClusterTestTypeClusterInformer(client clientset.ClusterInterface, resyncPeriod time.Duration, indexers cache.Indexers) cache.SharedIndexInformer {
+func NewClusterTestTypeClusterInformer(client clientset.ClusterInterface, resyncPeriod time.Duration, indexers cache.Indexers) kcpcache.ScopeableSharedIndexInformer {
 	return NewFilteredClusterTestTypeClusterInformer(client, resyncPeriod, indexers, nil)
 }
 
 // NewFilteredClusterTestTypeClusterInformer constructs a new informer for ClusterTestType type.
 // Always prefer using an informer factory to get a shared informer instead of getting an independent
 // one. This reduces memory footprint and number of connections to the server.
-func NewFilteredClusterTestTypeClusterInformer(client clientset.ClusterInterface, resyncPeriod time.Duration, indexers cache.Indexers, tweakListOptions internalinterfaces.TweakListOptionsFunc) cache.SharedIndexInformer {
+func NewFilteredClusterTestTypeClusterInformer(client clientset.ClusterInterface, resyncPeriod time.Duration, indexers cache.Indexers, tweakListOptions internalinterfaces.TweakListOptionsFunc) kcpcache.ScopeableSharedIndexInformer {
 	return kcpinformers.NewSharedIndexInformer(
 		&cache.ListWatch{
 			ListFunc: func(options metav1.ListOptions) (runtime.Object, error) {
@@ -83,7 +83,7 @@ func NewFilteredClusterTestTypeClusterInformer(client clientset.ClusterInterface
 	)
 }
 
-func (f *clusterTestTypeClusterInformer) defaultInformer(client clientset.ClusterInterface, resyncPeriod time.Duration) cache.SharedIndexInformer {
+func (f *clusterTestTypeClusterInformer) defaultInformer(client clientset.ClusterInterface, resyncPeriod time.Duration) kcpcache.ScopeableSharedIndexInformer {
 	return NewFilteredClusterTestTypeClusterInformer(client, resyncPeriod, cache.Indexers{
 		kcpcache.ClusterIndexName: kcpcache.ClusterIndexFunc,
 	},
@@ -91,7 +91,7 @@ func (f *clusterTestTypeClusterInformer) defaultInformer(client clientset.Cluste
 	)
 }
 
-func (f *clusterTestTypeClusterInformer) Informer() cache.SharedIndexInformer {
+func (f *clusterTestTypeClusterInformer) Informer() kcpcache.ScopeableSharedIndexInformer {
 	return f.factory.InformerFor(&examplev1beta1.ClusterTestType{}, f.defaultInformer)
 }
 

--- a/examples/pkg/kcp/clients/informers/example/v2/clustertesttype.go
+++ b/examples/pkg/kcp/clients/informers/example/v2/clustertesttype.go
@@ -42,7 +42,7 @@ import (
 // ClusterTestTypeClusterInformer provides access to a shared informer and lister for
 // ClusterTestTypes.
 type ClusterTestTypeClusterInformer interface {
-	Informer() cache.SharedIndexInformer
+	Informer() kcpcache.ScopeableSharedIndexInformer
 	Lister() examplev2listers.ClusterTestTypeClusterLister
 }
 
@@ -54,14 +54,14 @@ type clusterTestTypeClusterInformer struct {
 // NewClusterTestTypeClusterInformer constructs a new informer for ClusterTestType type.
 // Always prefer using an informer factory to get a shared informer instead of getting an independent
 // one. This reduces memory footprint and number of connections to the server.
-func NewClusterTestTypeClusterInformer(client clientset.ClusterInterface, resyncPeriod time.Duration, indexers cache.Indexers) cache.SharedIndexInformer {
+func NewClusterTestTypeClusterInformer(client clientset.ClusterInterface, resyncPeriod time.Duration, indexers cache.Indexers) kcpcache.ScopeableSharedIndexInformer {
 	return NewFilteredClusterTestTypeClusterInformer(client, resyncPeriod, indexers, nil)
 }
 
 // NewFilteredClusterTestTypeClusterInformer constructs a new informer for ClusterTestType type.
 // Always prefer using an informer factory to get a shared informer instead of getting an independent
 // one. This reduces memory footprint and number of connections to the server.
-func NewFilteredClusterTestTypeClusterInformer(client clientset.ClusterInterface, resyncPeriod time.Duration, indexers cache.Indexers, tweakListOptions internalinterfaces.TweakListOptionsFunc) cache.SharedIndexInformer {
+func NewFilteredClusterTestTypeClusterInformer(client clientset.ClusterInterface, resyncPeriod time.Duration, indexers cache.Indexers, tweakListOptions internalinterfaces.TweakListOptionsFunc) kcpcache.ScopeableSharedIndexInformer {
 	return kcpinformers.NewSharedIndexInformer(
 		&cache.ListWatch{
 			ListFunc: func(options metav1.ListOptions) (runtime.Object, error) {
@@ -83,7 +83,7 @@ func NewFilteredClusterTestTypeClusterInformer(client clientset.ClusterInterface
 	)
 }
 
-func (f *clusterTestTypeClusterInformer) defaultInformer(client clientset.ClusterInterface, resyncPeriod time.Duration) cache.SharedIndexInformer {
+func (f *clusterTestTypeClusterInformer) defaultInformer(client clientset.ClusterInterface, resyncPeriod time.Duration) kcpcache.ScopeableSharedIndexInformer {
 	return NewFilteredClusterTestTypeClusterInformer(client, resyncPeriod, cache.Indexers{
 		kcpcache.ClusterIndexName: kcpcache.ClusterIndexFunc,
 	},
@@ -91,7 +91,7 @@ func (f *clusterTestTypeClusterInformer) defaultInformer(client clientset.Cluste
 	)
 }
 
-func (f *clusterTestTypeClusterInformer) Informer() cache.SharedIndexInformer {
+func (f *clusterTestTypeClusterInformer) Informer() kcpcache.ScopeableSharedIndexInformer {
 	return f.factory.InformerFor(&examplev2.ClusterTestType{}, f.defaultInformer)
 }
 

--- a/examples/pkg/kcp/clients/informers/example/v2/testtype.go
+++ b/examples/pkg/kcp/clients/informers/example/v2/testtype.go
@@ -42,7 +42,7 @@ import (
 // TestTypeClusterInformer provides access to a shared informer and lister for
 // TestTypes.
 type TestTypeClusterInformer interface {
-	Informer() cache.SharedIndexInformer
+	Informer() kcpcache.ScopeableSharedIndexInformer
 	Lister() examplev2listers.TestTypeClusterLister
 }
 
@@ -54,14 +54,14 @@ type testTypeClusterInformer struct {
 // NewTestTypeClusterInformer constructs a new informer for TestType type.
 // Always prefer using an informer factory to get a shared informer instead of getting an independent
 // one. This reduces memory footprint and number of connections to the server.
-func NewTestTypeClusterInformer(client clientset.ClusterInterface, resyncPeriod time.Duration, indexers cache.Indexers) cache.SharedIndexInformer {
+func NewTestTypeClusterInformer(client clientset.ClusterInterface, resyncPeriod time.Duration, indexers cache.Indexers) kcpcache.ScopeableSharedIndexInformer {
 	return NewFilteredTestTypeClusterInformer(client, resyncPeriod, indexers, nil)
 }
 
 // NewFilteredTestTypeClusterInformer constructs a new informer for TestType type.
 // Always prefer using an informer factory to get a shared informer instead of getting an independent
 // one. This reduces memory footprint and number of connections to the server.
-func NewFilteredTestTypeClusterInformer(client clientset.ClusterInterface, resyncPeriod time.Duration, indexers cache.Indexers, tweakListOptions internalinterfaces.TweakListOptionsFunc) cache.SharedIndexInformer {
+func NewFilteredTestTypeClusterInformer(client clientset.ClusterInterface, resyncPeriod time.Duration, indexers cache.Indexers, tweakListOptions internalinterfaces.TweakListOptionsFunc) kcpcache.ScopeableSharedIndexInformer {
 	return kcpinformers.NewSharedIndexInformer(
 		&cache.ListWatch{
 			ListFunc: func(options metav1.ListOptions) (runtime.Object, error) {
@@ -83,7 +83,7 @@ func NewFilteredTestTypeClusterInformer(client clientset.ClusterInterface, resyn
 	)
 }
 
-func (f *testTypeClusterInformer) defaultInformer(client clientset.ClusterInterface, resyncPeriod time.Duration) cache.SharedIndexInformer {
+func (f *testTypeClusterInformer) defaultInformer(client clientset.ClusterInterface, resyncPeriod time.Duration) kcpcache.ScopeableSharedIndexInformer {
 	return NewFilteredTestTypeClusterInformer(client, resyncPeriod, cache.Indexers{
 		kcpcache.ClusterIndexName:             kcpcache.ClusterIndexFunc,
 		kcpcache.ClusterAndNamespaceIndexName: kcpcache.ClusterAndNamespaceIndexFunc},
@@ -91,7 +91,7 @@ func (f *testTypeClusterInformer) defaultInformer(client clientset.ClusterInterf
 	)
 }
 
-func (f *testTypeClusterInformer) Informer() cache.SharedIndexInformer {
+func (f *testTypeClusterInformer) Informer() kcpcache.ScopeableSharedIndexInformer {
 	return f.factory.InformerFor(&examplev2.TestType{}, f.defaultInformer)
 }
 

--- a/examples/pkg/kcp/clients/informers/example3/v1/clustertesttype.go
+++ b/examples/pkg/kcp/clients/informers/example3/v1/clustertesttype.go
@@ -42,7 +42,7 @@ import (
 // ClusterTestTypeClusterInformer provides access to a shared informer and lister for
 // ClusterTestTypes.
 type ClusterTestTypeClusterInformer interface {
-	Informer() cache.SharedIndexInformer
+	Informer() kcpcache.ScopeableSharedIndexInformer
 	Lister() example3v1listers.ClusterTestTypeClusterLister
 }
 
@@ -54,14 +54,14 @@ type clusterTestTypeClusterInformer struct {
 // NewClusterTestTypeClusterInformer constructs a new informer for ClusterTestType type.
 // Always prefer using an informer factory to get a shared informer instead of getting an independent
 // one. This reduces memory footprint and number of connections to the server.
-func NewClusterTestTypeClusterInformer(client clientset.ClusterInterface, resyncPeriod time.Duration, indexers cache.Indexers) cache.SharedIndexInformer {
+func NewClusterTestTypeClusterInformer(client clientset.ClusterInterface, resyncPeriod time.Duration, indexers cache.Indexers) kcpcache.ScopeableSharedIndexInformer {
 	return NewFilteredClusterTestTypeClusterInformer(client, resyncPeriod, indexers, nil)
 }
 
 // NewFilteredClusterTestTypeClusterInformer constructs a new informer for ClusterTestType type.
 // Always prefer using an informer factory to get a shared informer instead of getting an independent
 // one. This reduces memory footprint and number of connections to the server.
-func NewFilteredClusterTestTypeClusterInformer(client clientset.ClusterInterface, resyncPeriod time.Duration, indexers cache.Indexers, tweakListOptions internalinterfaces.TweakListOptionsFunc) cache.SharedIndexInformer {
+func NewFilteredClusterTestTypeClusterInformer(client clientset.ClusterInterface, resyncPeriod time.Duration, indexers cache.Indexers, tweakListOptions internalinterfaces.TweakListOptionsFunc) kcpcache.ScopeableSharedIndexInformer {
 	return kcpinformers.NewSharedIndexInformer(
 		&cache.ListWatch{
 			ListFunc: func(options metav1.ListOptions) (runtime.Object, error) {
@@ -83,7 +83,7 @@ func NewFilteredClusterTestTypeClusterInformer(client clientset.ClusterInterface
 	)
 }
 
-func (f *clusterTestTypeClusterInformer) defaultInformer(client clientset.ClusterInterface, resyncPeriod time.Duration) cache.SharedIndexInformer {
+func (f *clusterTestTypeClusterInformer) defaultInformer(client clientset.ClusterInterface, resyncPeriod time.Duration) kcpcache.ScopeableSharedIndexInformer {
 	return NewFilteredClusterTestTypeClusterInformer(client, resyncPeriod, cache.Indexers{
 		kcpcache.ClusterIndexName: kcpcache.ClusterIndexFunc,
 	},
@@ -91,7 +91,7 @@ func (f *clusterTestTypeClusterInformer) defaultInformer(client clientset.Cluste
 	)
 }
 
-func (f *clusterTestTypeClusterInformer) Informer() cache.SharedIndexInformer {
+func (f *clusterTestTypeClusterInformer) Informer() kcpcache.ScopeableSharedIndexInformer {
 	return f.factory.InformerFor(&example3v1.ClusterTestType{}, f.defaultInformer)
 }
 

--- a/examples/pkg/kcp/clients/informers/example3/v1/testtype.go
+++ b/examples/pkg/kcp/clients/informers/example3/v1/testtype.go
@@ -42,7 +42,7 @@ import (
 // TestTypeClusterInformer provides access to a shared informer and lister for
 // TestTypes.
 type TestTypeClusterInformer interface {
-	Informer() cache.SharedIndexInformer
+	Informer() kcpcache.ScopeableSharedIndexInformer
 	Lister() example3v1listers.TestTypeClusterLister
 }
 
@@ -54,14 +54,14 @@ type testTypeClusterInformer struct {
 // NewTestTypeClusterInformer constructs a new informer for TestType type.
 // Always prefer using an informer factory to get a shared informer instead of getting an independent
 // one. This reduces memory footprint and number of connections to the server.
-func NewTestTypeClusterInformer(client clientset.ClusterInterface, resyncPeriod time.Duration, indexers cache.Indexers) cache.SharedIndexInformer {
+func NewTestTypeClusterInformer(client clientset.ClusterInterface, resyncPeriod time.Duration, indexers cache.Indexers) kcpcache.ScopeableSharedIndexInformer {
 	return NewFilteredTestTypeClusterInformer(client, resyncPeriod, indexers, nil)
 }
 
 // NewFilteredTestTypeClusterInformer constructs a new informer for TestType type.
 // Always prefer using an informer factory to get a shared informer instead of getting an independent
 // one. This reduces memory footprint and number of connections to the server.
-func NewFilteredTestTypeClusterInformer(client clientset.ClusterInterface, resyncPeriod time.Duration, indexers cache.Indexers, tweakListOptions internalinterfaces.TweakListOptionsFunc) cache.SharedIndexInformer {
+func NewFilteredTestTypeClusterInformer(client clientset.ClusterInterface, resyncPeriod time.Duration, indexers cache.Indexers, tweakListOptions internalinterfaces.TweakListOptionsFunc) kcpcache.ScopeableSharedIndexInformer {
 	return kcpinformers.NewSharedIndexInformer(
 		&cache.ListWatch{
 			ListFunc: func(options metav1.ListOptions) (runtime.Object, error) {
@@ -83,7 +83,7 @@ func NewFilteredTestTypeClusterInformer(client clientset.ClusterInterface, resyn
 	)
 }
 
-func (f *testTypeClusterInformer) defaultInformer(client clientset.ClusterInterface, resyncPeriod time.Duration) cache.SharedIndexInformer {
+func (f *testTypeClusterInformer) defaultInformer(client clientset.ClusterInterface, resyncPeriod time.Duration) kcpcache.ScopeableSharedIndexInformer {
 	return NewFilteredTestTypeClusterInformer(client, resyncPeriod, cache.Indexers{
 		kcpcache.ClusterIndexName:             kcpcache.ClusterIndexFunc,
 		kcpcache.ClusterAndNamespaceIndexName: kcpcache.ClusterAndNamespaceIndexFunc},
@@ -91,7 +91,7 @@ func (f *testTypeClusterInformer) defaultInformer(client clientset.ClusterInterf
 	)
 }
 
-func (f *testTypeClusterInformer) Informer() cache.SharedIndexInformer {
+func (f *testTypeClusterInformer) Informer() kcpcache.ScopeableSharedIndexInformer {
 	return f.factory.InformerFor(&example3v1.TestType{}, f.defaultInformer)
 }
 

--- a/examples/pkg/kcp/clients/informers/existinginterfaces/v1/clustertesttype.go
+++ b/examples/pkg/kcp/clients/informers/existinginterfaces/v1/clustertesttype.go
@@ -42,7 +42,7 @@ import (
 // ClusterTestTypeClusterInformer provides access to a shared informer and lister for
 // ClusterTestTypes.
 type ClusterTestTypeClusterInformer interface {
-	Informer() cache.SharedIndexInformer
+	Informer() kcpcache.ScopeableSharedIndexInformer
 	Lister() existinginterfacesv1listers.ClusterTestTypeClusterLister
 }
 
@@ -54,14 +54,14 @@ type clusterTestTypeClusterInformer struct {
 // NewClusterTestTypeClusterInformer constructs a new informer for ClusterTestType type.
 // Always prefer using an informer factory to get a shared informer instead of getting an independent
 // one. This reduces memory footprint and number of connections to the server.
-func NewClusterTestTypeClusterInformer(client clientset.ClusterInterface, resyncPeriod time.Duration, indexers cache.Indexers) cache.SharedIndexInformer {
+func NewClusterTestTypeClusterInformer(client clientset.ClusterInterface, resyncPeriod time.Duration, indexers cache.Indexers) kcpcache.ScopeableSharedIndexInformer {
 	return NewFilteredClusterTestTypeClusterInformer(client, resyncPeriod, indexers, nil)
 }
 
 // NewFilteredClusterTestTypeClusterInformer constructs a new informer for ClusterTestType type.
 // Always prefer using an informer factory to get a shared informer instead of getting an independent
 // one. This reduces memory footprint and number of connections to the server.
-func NewFilteredClusterTestTypeClusterInformer(client clientset.ClusterInterface, resyncPeriod time.Duration, indexers cache.Indexers, tweakListOptions internalinterfaces.TweakListOptionsFunc) cache.SharedIndexInformer {
+func NewFilteredClusterTestTypeClusterInformer(client clientset.ClusterInterface, resyncPeriod time.Duration, indexers cache.Indexers, tweakListOptions internalinterfaces.TweakListOptionsFunc) kcpcache.ScopeableSharedIndexInformer {
 	return kcpinformers.NewSharedIndexInformer(
 		&cache.ListWatch{
 			ListFunc: func(options metav1.ListOptions) (runtime.Object, error) {
@@ -83,7 +83,7 @@ func NewFilteredClusterTestTypeClusterInformer(client clientset.ClusterInterface
 	)
 }
 
-func (f *clusterTestTypeClusterInformer) defaultInformer(client clientset.ClusterInterface, resyncPeriod time.Duration) cache.SharedIndexInformer {
+func (f *clusterTestTypeClusterInformer) defaultInformer(client clientset.ClusterInterface, resyncPeriod time.Duration) kcpcache.ScopeableSharedIndexInformer {
 	return NewFilteredClusterTestTypeClusterInformer(client, resyncPeriod, cache.Indexers{
 		kcpcache.ClusterIndexName: kcpcache.ClusterIndexFunc,
 	},
@@ -91,7 +91,7 @@ func (f *clusterTestTypeClusterInformer) defaultInformer(client clientset.Cluste
 	)
 }
 
-func (f *clusterTestTypeClusterInformer) Informer() cache.SharedIndexInformer {
+func (f *clusterTestTypeClusterInformer) Informer() kcpcache.ScopeableSharedIndexInformer {
 	return f.factory.InformerFor(&existinginterfacesv1.ClusterTestType{}, f.defaultInformer)
 }
 

--- a/examples/pkg/kcp/clients/informers/existinginterfaces/v1/testtype.go
+++ b/examples/pkg/kcp/clients/informers/existinginterfaces/v1/testtype.go
@@ -42,7 +42,7 @@ import (
 // TestTypeClusterInformer provides access to a shared informer and lister for
 // TestTypes.
 type TestTypeClusterInformer interface {
-	Informer() cache.SharedIndexInformer
+	Informer() kcpcache.ScopeableSharedIndexInformer
 	Lister() existinginterfacesv1listers.TestTypeClusterLister
 }
 
@@ -54,14 +54,14 @@ type testTypeClusterInformer struct {
 // NewTestTypeClusterInformer constructs a new informer for TestType type.
 // Always prefer using an informer factory to get a shared informer instead of getting an independent
 // one. This reduces memory footprint and number of connections to the server.
-func NewTestTypeClusterInformer(client clientset.ClusterInterface, resyncPeriod time.Duration, indexers cache.Indexers) cache.SharedIndexInformer {
+func NewTestTypeClusterInformer(client clientset.ClusterInterface, resyncPeriod time.Duration, indexers cache.Indexers) kcpcache.ScopeableSharedIndexInformer {
 	return NewFilteredTestTypeClusterInformer(client, resyncPeriod, indexers, nil)
 }
 
 // NewFilteredTestTypeClusterInformer constructs a new informer for TestType type.
 // Always prefer using an informer factory to get a shared informer instead of getting an independent
 // one. This reduces memory footprint and number of connections to the server.
-func NewFilteredTestTypeClusterInformer(client clientset.ClusterInterface, resyncPeriod time.Duration, indexers cache.Indexers, tweakListOptions internalinterfaces.TweakListOptionsFunc) cache.SharedIndexInformer {
+func NewFilteredTestTypeClusterInformer(client clientset.ClusterInterface, resyncPeriod time.Duration, indexers cache.Indexers, tweakListOptions internalinterfaces.TweakListOptionsFunc) kcpcache.ScopeableSharedIndexInformer {
 	return kcpinformers.NewSharedIndexInformer(
 		&cache.ListWatch{
 			ListFunc: func(options metav1.ListOptions) (runtime.Object, error) {
@@ -83,7 +83,7 @@ func NewFilteredTestTypeClusterInformer(client clientset.ClusterInterface, resyn
 	)
 }
 
-func (f *testTypeClusterInformer) defaultInformer(client clientset.ClusterInterface, resyncPeriod time.Duration) cache.SharedIndexInformer {
+func (f *testTypeClusterInformer) defaultInformer(client clientset.ClusterInterface, resyncPeriod time.Duration) kcpcache.ScopeableSharedIndexInformer {
 	return NewFilteredTestTypeClusterInformer(client, resyncPeriod, cache.Indexers{
 		kcpcache.ClusterIndexName:             kcpcache.ClusterIndexFunc,
 		kcpcache.ClusterAndNamespaceIndexName: kcpcache.ClusterAndNamespaceIndexFunc},
@@ -91,7 +91,7 @@ func (f *testTypeClusterInformer) defaultInformer(client clientset.ClusterInterf
 	)
 }
 
-func (f *testTypeClusterInformer) Informer() cache.SharedIndexInformer {
+func (f *testTypeClusterInformer) Informer() kcpcache.ScopeableSharedIndexInformer {
 	return f.factory.InformerFor(&existinginterfacesv1.TestType{}, f.defaultInformer)
 }
 

--- a/examples/pkg/kcp/clients/informers/factory.go
+++ b/examples/pkg/kcp/clients/informers/factory.go
@@ -26,6 +26,8 @@ import (
 	"sync"
 	"time"
 
+	kcpcache "github.com/kcp-dev/apimachinery/pkg/cache"
+
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/runtime/schema"
@@ -49,7 +51,7 @@ type sharedInformerFactory struct {
 	defaultResync    time.Duration
 	customResync     map[reflect.Type]time.Duration
 
-	informers map[reflect.Type]cache.SharedIndexInformer
+	informers map[reflect.Type]kcpcache.ScopeableSharedIndexInformer
 	// startedInformers is used for tracking which informers have been started.
 	// This allows Start() to be called multiple times safely.
 	startedInformers map[reflect.Type]bool
@@ -83,7 +85,7 @@ func NewSharedInformerFactoryWithOptions(client clientset.ClusterInterface, defa
 	factory := &sharedInformerFactory{
 		client:           client,
 		defaultResync:    defaultResync,
-		informers:        make(map[reflect.Type]cache.SharedIndexInformer),
+		informers:        make(map[reflect.Type]kcpcache.ScopeableSharedIndexInformer),
 		startedInformers: make(map[reflect.Type]bool),
 		customResync:     make(map[reflect.Type]time.Duration),
 	}
@@ -111,11 +113,11 @@ func (f *sharedInformerFactory) Start(stopCh <-chan struct{}) {
 
 // WaitForCacheSync waits for all started informers' cache were synced.
 func (f *sharedInformerFactory) WaitForCacheSync(stopCh <-chan struct{}) map[reflect.Type]bool {
-	informers := func() map[reflect.Type]cache.SharedIndexInformer {
+	informers := func() map[reflect.Type]kcpcache.ScopeableSharedIndexInformer {
 		f.lock.Lock()
 		defer f.lock.Unlock()
 
-		informers := map[reflect.Type]cache.SharedIndexInformer{}
+		informers := map[reflect.Type]kcpcache.ScopeableSharedIndexInformer{}
 		for informerType, informer := range f.informers {
 			if f.startedInformers[informerType] {
 				informers[informerType] = informer
@@ -133,7 +135,7 @@ func (f *sharedInformerFactory) WaitForCacheSync(stopCh <-chan struct{}) map[ref
 
 // InternalInformerFor returns the SharedIndexInformer for obj using an internal
 // client.
-func (f *sharedInformerFactory) InformerFor(obj runtime.Object, newFunc internalinterfaces.NewInformerFunc) cache.SharedIndexInformer {
+func (f *sharedInformerFactory) InformerFor(obj runtime.Object, newFunc internalinterfaces.NewInformerFunc) kcpcache.ScopeableSharedIndexInformer {
 	f.lock.Lock()
 	defer f.lock.Unlock()
 

--- a/examples/pkg/kcp/clients/informers/generic.go
+++ b/examples/pkg/kcp/clients/informers/generic.go
@@ -27,7 +27,6 @@ import (
 	kcpcache "github.com/kcp-dev/apimachinery/pkg/cache"
 
 	"k8s.io/apimachinery/pkg/runtime/schema"
-	"k8s.io/client-go/tools/cache"
 
 	examplev1 "acme.corp/pkg/apis/example/v1"
 	examplev1alpha1 "acme.corp/pkg/apis/example/v1alpha1"
@@ -39,17 +38,17 @@ import (
 )
 
 type GenericClusterInformer interface {
-	Informer() cache.SharedIndexInformer
+	Informer() kcpcache.ScopeableSharedIndexInformer
 	Lister() kcpcache.GenericClusterLister
 }
 
 type genericClusterInformer struct {
-	informer cache.SharedIndexInformer
+	informer kcpcache.ScopeableSharedIndexInformer
 	resource schema.GroupResource
 }
 
 // Informer returns the SharedIndexInformer.
-func (f *genericClusterInformer) Informer() cache.SharedIndexInformer {
+func (f *genericClusterInformer) Informer() kcpcache.ScopeableSharedIndexInformer {
 	return f.informer
 }
 

--- a/examples/pkg/kcp/clients/informers/internalinterfaces/factory_interfaces.go
+++ b/examples/pkg/kcp/clients/informers/internalinterfaces/factory_interfaces.go
@@ -24,20 +24,21 @@ package internalinterfaces
 import (
 	time "time"
 
+	kcpcache "github.com/kcp-dev/apimachinery/pkg/cache"
+
 	v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	runtime "k8s.io/apimachinery/pkg/runtime"
-	cache "k8s.io/client-go/tools/cache"
 
 	client "acme.corp/pkg/kcp/clients/clientset/versioned"
 )
 
-// NewInformerFunc takes client.ClusterInterface and time.Duration to return a SharedIndexInformer.
-type NewInformerFunc func(client.ClusterInterface, time.Duration) cache.SharedIndexInformer
+// NewInformerFunc takes client.ClusterInterface and time.Duration to return a ScopeableSharedIndexInformer.
+type NewInformerFunc func(client.ClusterInterface, time.Duration) kcpcache.ScopeableSharedIndexInformer
 
 // SharedInformerFactory a small interface to allow for adding an informer without an import cycle
 type SharedInformerFactory interface {
 	Start(stopCh <-chan struct{})
-	InformerFor(obj runtime.Object, newFunc NewInformerFunc) cache.SharedIndexInformer
+	InformerFor(obj runtime.Object, newFunc NewInformerFunc) kcpcache.ScopeableSharedIndexInformer
 }
 
 // TweakListOptionsFunc is a function that transforms a v1.ListOptions.

--- a/examples/pkg/kcp/clients/informers/secondexample/v1/clustertesttype.go
+++ b/examples/pkg/kcp/clients/informers/secondexample/v1/clustertesttype.go
@@ -42,7 +42,7 @@ import (
 // ClusterTestTypeClusterInformer provides access to a shared informer and lister for
 // ClusterTestTypes.
 type ClusterTestTypeClusterInformer interface {
-	Informer() cache.SharedIndexInformer
+	Informer() kcpcache.ScopeableSharedIndexInformer
 	Lister() secondexamplev1listers.ClusterTestTypeClusterLister
 }
 
@@ -54,14 +54,14 @@ type clusterTestTypeClusterInformer struct {
 // NewClusterTestTypeClusterInformer constructs a new informer for ClusterTestType type.
 // Always prefer using an informer factory to get a shared informer instead of getting an independent
 // one. This reduces memory footprint and number of connections to the server.
-func NewClusterTestTypeClusterInformer(client clientset.ClusterInterface, resyncPeriod time.Duration, indexers cache.Indexers) cache.SharedIndexInformer {
+func NewClusterTestTypeClusterInformer(client clientset.ClusterInterface, resyncPeriod time.Duration, indexers cache.Indexers) kcpcache.ScopeableSharedIndexInformer {
 	return NewFilteredClusterTestTypeClusterInformer(client, resyncPeriod, indexers, nil)
 }
 
 // NewFilteredClusterTestTypeClusterInformer constructs a new informer for ClusterTestType type.
 // Always prefer using an informer factory to get a shared informer instead of getting an independent
 // one. This reduces memory footprint and number of connections to the server.
-func NewFilteredClusterTestTypeClusterInformer(client clientset.ClusterInterface, resyncPeriod time.Duration, indexers cache.Indexers, tweakListOptions internalinterfaces.TweakListOptionsFunc) cache.SharedIndexInformer {
+func NewFilteredClusterTestTypeClusterInformer(client clientset.ClusterInterface, resyncPeriod time.Duration, indexers cache.Indexers, tweakListOptions internalinterfaces.TweakListOptionsFunc) kcpcache.ScopeableSharedIndexInformer {
 	return kcpinformers.NewSharedIndexInformer(
 		&cache.ListWatch{
 			ListFunc: func(options metav1.ListOptions) (runtime.Object, error) {
@@ -83,7 +83,7 @@ func NewFilteredClusterTestTypeClusterInformer(client clientset.ClusterInterface
 	)
 }
 
-func (f *clusterTestTypeClusterInformer) defaultInformer(client clientset.ClusterInterface, resyncPeriod time.Duration) cache.SharedIndexInformer {
+func (f *clusterTestTypeClusterInformer) defaultInformer(client clientset.ClusterInterface, resyncPeriod time.Duration) kcpcache.ScopeableSharedIndexInformer {
 	return NewFilteredClusterTestTypeClusterInformer(client, resyncPeriod, cache.Indexers{
 		kcpcache.ClusterIndexName: kcpcache.ClusterIndexFunc,
 	},
@@ -91,7 +91,7 @@ func (f *clusterTestTypeClusterInformer) defaultInformer(client clientset.Cluste
 	)
 }
 
-func (f *clusterTestTypeClusterInformer) Informer() cache.SharedIndexInformer {
+func (f *clusterTestTypeClusterInformer) Informer() kcpcache.ScopeableSharedIndexInformer {
 	return f.factory.InformerFor(&secondexamplev1.ClusterTestType{}, f.defaultInformer)
 }
 

--- a/examples/pkg/kcp/clients/informers/secondexample/v1/testtype.go
+++ b/examples/pkg/kcp/clients/informers/secondexample/v1/testtype.go
@@ -42,7 +42,7 @@ import (
 // TestTypeClusterInformer provides access to a shared informer and lister for
 // TestTypes.
 type TestTypeClusterInformer interface {
-	Informer() cache.SharedIndexInformer
+	Informer() kcpcache.ScopeableSharedIndexInformer
 	Lister() secondexamplev1listers.TestTypeClusterLister
 }
 
@@ -54,14 +54,14 @@ type testTypeClusterInformer struct {
 // NewTestTypeClusterInformer constructs a new informer for TestType type.
 // Always prefer using an informer factory to get a shared informer instead of getting an independent
 // one. This reduces memory footprint and number of connections to the server.
-func NewTestTypeClusterInformer(client clientset.ClusterInterface, resyncPeriod time.Duration, indexers cache.Indexers) cache.SharedIndexInformer {
+func NewTestTypeClusterInformer(client clientset.ClusterInterface, resyncPeriod time.Duration, indexers cache.Indexers) kcpcache.ScopeableSharedIndexInformer {
 	return NewFilteredTestTypeClusterInformer(client, resyncPeriod, indexers, nil)
 }
 
 // NewFilteredTestTypeClusterInformer constructs a new informer for TestType type.
 // Always prefer using an informer factory to get a shared informer instead of getting an independent
 // one. This reduces memory footprint and number of connections to the server.
-func NewFilteredTestTypeClusterInformer(client clientset.ClusterInterface, resyncPeriod time.Duration, indexers cache.Indexers, tweakListOptions internalinterfaces.TweakListOptionsFunc) cache.SharedIndexInformer {
+func NewFilteredTestTypeClusterInformer(client clientset.ClusterInterface, resyncPeriod time.Duration, indexers cache.Indexers, tweakListOptions internalinterfaces.TweakListOptionsFunc) kcpcache.ScopeableSharedIndexInformer {
 	return kcpinformers.NewSharedIndexInformer(
 		&cache.ListWatch{
 			ListFunc: func(options metav1.ListOptions) (runtime.Object, error) {
@@ -83,7 +83,7 @@ func NewFilteredTestTypeClusterInformer(client clientset.ClusterInterface, resyn
 	)
 }
 
-func (f *testTypeClusterInformer) defaultInformer(client clientset.ClusterInterface, resyncPeriod time.Duration) cache.SharedIndexInformer {
+func (f *testTypeClusterInformer) defaultInformer(client clientset.ClusterInterface, resyncPeriod time.Duration) kcpcache.ScopeableSharedIndexInformer {
 	return NewFilteredTestTypeClusterInformer(client, resyncPeriod, cache.Indexers{
 		kcpcache.ClusterIndexName:             kcpcache.ClusterIndexFunc,
 		kcpcache.ClusterAndNamespaceIndexName: kcpcache.ClusterAndNamespaceIndexFunc},
@@ -91,7 +91,7 @@ func (f *testTypeClusterInformer) defaultInformer(client clientset.ClusterInterf
 	)
 }
 
-func (f *testTypeClusterInformer) Informer() cache.SharedIndexInformer {
+func (f *testTypeClusterInformer) Informer() kcpcache.ScopeableSharedIndexInformer {
 	return f.factory.InformerFor(&secondexamplev1.TestType{}, f.defaultInformer)
 }
 

--- a/examples/pkg/kcpexisting/clients/clientset/versioned/fake/clientset.go
+++ b/examples/pkg/kcpexisting/clients/clientset/versioned/fake/clientset.go
@@ -22,8 +22,6 @@ limitations under the License.
 package fake
 
 import (
-	"fmt"
-
 	"github.com/kcp-dev/logicalcluster/v2"
 
 	kcpfakediscovery "github.com/kcp-dev/client-go/third_party/k8s.io/client-go/discovery/fake"
@@ -63,15 +61,7 @@ import (
 // for a real clientset and is mostly useful in simple unit tests.
 func NewSimpleClientset(objects ...runtime.Object) *ClusterClientset {
 	o := kcptesting.NewObjectTracker(clientscheme.Scheme, clientscheme.Codecs.UniversalDecoder())
-	for _, obj := range objects {
-		metaObj, ok := obj.(logicalcluster.Object)
-		if !ok {
-			panic(fmt.Sprintf("cannot extract logical cluster from %T", obj))
-		}
-		if err := o.Cluster(logicalcluster.From(metaObj)).Add(obj); err != nil {
-			panic(err)
-		}
-	}
+	o.AddAll(objects...)
 
 	cs := &ClusterClientset{Fake: &kcptesting.Fake{}, tracker: o}
 	cs.discovery = &kcpfakediscovery.FakeDiscovery{Fake: cs.Fake, Cluster: logicalcluster.Wildcard}

--- a/examples/pkg/kcpexisting/clients/clientset/versioned/fake/typed/example/v1/clustertesttype.go
+++ b/examples/pkg/kcpexisting/clients/clientset/versioned/fake/typed/example/v1/clustertesttype.go
@@ -41,8 +41,8 @@ import (
 	examplev1client "acme.corp/pkg/generated/clientset/versioned/typed/example/v1"
 )
 
-var clusterTestTypesResource = schema.GroupVersionResource{Group: "example", Version: "V1", Resource: "clustertesttypes"}
-var clusterTestTypesKind = schema.GroupVersionKind{Group: "example", Version: "V1", Kind: "ClusterTestType"}
+var clusterTestTypesResource = schema.GroupVersionResource{Group: "example", Version: "v1", Resource: "clustertesttypes"}
+var clusterTestTypesKind = schema.GroupVersionKind{Group: "example", Version: "v1", Kind: "ClusterTestType"}
 
 type clusterTestTypesClusterClient struct {
 	*kcptesting.Fake

--- a/examples/pkg/kcpexisting/clients/clientset/versioned/fake/typed/example/v1/testtype.go
+++ b/examples/pkg/kcpexisting/clients/clientset/versioned/fake/typed/example/v1/testtype.go
@@ -42,8 +42,8 @@ import (
 	kcpexamplev1 "acme.corp/pkg/kcp/clients/clientset/versioned/typed/example/v1"
 )
 
-var testTypesResource = schema.GroupVersionResource{Group: "example", Version: "V1", Resource: "testtypes"}
-var testTypesKind = schema.GroupVersionKind{Group: "example", Version: "V1", Kind: "TestType"}
+var testTypesResource = schema.GroupVersionResource{Group: "example", Version: "v1", Resource: "testtypes"}
+var testTypesKind = schema.GroupVersionKind{Group: "example", Version: "v1", Kind: "TestType"}
 
 type testTypesClusterClient struct {
 	*kcptesting.Fake

--- a/examples/pkg/kcpexisting/clients/clientset/versioned/fake/typed/example/v1/withoutverbtype.go
+++ b/examples/pkg/kcpexisting/clients/clientset/versioned/fake/typed/example/v1/withoutverbtype.go
@@ -31,8 +31,8 @@ import (
 	kcpexamplev1 "acme.corp/pkg/kcp/clients/clientset/versioned/typed/example/v1"
 )
 
-var withoutVerbTypesResource = schema.GroupVersionResource{Group: "example", Version: "V1", Resource: "withoutverbtypes"}
-var withoutVerbTypesKind = schema.GroupVersionKind{Group: "example", Version: "V1", Kind: "WithoutVerbType"}
+var withoutVerbTypesResource = schema.GroupVersionResource{Group: "example", Version: "v1", Resource: "withoutverbtypes"}
+var withoutVerbTypesKind = schema.GroupVersionKind{Group: "example", Version: "v1", Kind: "WithoutVerbType"}
 
 type withoutVerbTypesClusterClient struct {
 	*kcptesting.Fake

--- a/examples/pkg/kcpexisting/clients/clientset/versioned/fake/typed/example/v1alpha1/clustertesttype.go
+++ b/examples/pkg/kcpexisting/clients/clientset/versioned/fake/typed/example/v1alpha1/clustertesttype.go
@@ -41,8 +41,8 @@ import (
 	examplev1alpha1client "acme.corp/pkg/generated/clientset/versioned/typed/example/v1alpha1"
 )
 
-var clusterTestTypesResource = schema.GroupVersionResource{Group: "example", Version: "V1alpha1", Resource: "clustertesttypes"}
-var clusterTestTypesKind = schema.GroupVersionKind{Group: "example", Version: "V1alpha1", Kind: "ClusterTestType"}
+var clusterTestTypesResource = schema.GroupVersionResource{Group: "example", Version: "v1alpha1", Resource: "clustertesttypes"}
+var clusterTestTypesKind = schema.GroupVersionKind{Group: "example", Version: "v1alpha1", Kind: "ClusterTestType"}
 
 type clusterTestTypesClusterClient struct {
 	*kcptesting.Fake

--- a/examples/pkg/kcpexisting/clients/clientset/versioned/fake/typed/example/v1alpha1/testtype.go
+++ b/examples/pkg/kcpexisting/clients/clientset/versioned/fake/typed/example/v1alpha1/testtype.go
@@ -42,8 +42,8 @@ import (
 	kcpexamplev1alpha1 "acme.corp/pkg/kcp/clients/clientset/versioned/typed/example/v1alpha1"
 )
 
-var testTypesResource = schema.GroupVersionResource{Group: "example", Version: "V1alpha1", Resource: "testtypes"}
-var testTypesKind = schema.GroupVersionKind{Group: "example", Version: "V1alpha1", Kind: "TestType"}
+var testTypesResource = schema.GroupVersionResource{Group: "example", Version: "v1alpha1", Resource: "testtypes"}
+var testTypesKind = schema.GroupVersionKind{Group: "example", Version: "v1alpha1", Kind: "TestType"}
 
 type testTypesClusterClient struct {
 	*kcptesting.Fake

--- a/examples/pkg/kcpexisting/clients/clientset/versioned/fake/typed/example/v1beta1/clustertesttype.go
+++ b/examples/pkg/kcpexisting/clients/clientset/versioned/fake/typed/example/v1beta1/clustertesttype.go
@@ -41,8 +41,8 @@ import (
 	examplev1beta1client "acme.corp/pkg/generated/clientset/versioned/typed/example/v1beta1"
 )
 
-var clusterTestTypesResource = schema.GroupVersionResource{Group: "example", Version: "V1beta1", Resource: "clustertesttypes"}
-var clusterTestTypesKind = schema.GroupVersionKind{Group: "example", Version: "V1beta1", Kind: "ClusterTestType"}
+var clusterTestTypesResource = schema.GroupVersionResource{Group: "example", Version: "v1beta1", Resource: "clustertesttypes"}
+var clusterTestTypesKind = schema.GroupVersionKind{Group: "example", Version: "v1beta1", Kind: "ClusterTestType"}
 
 type clusterTestTypesClusterClient struct {
 	*kcptesting.Fake

--- a/examples/pkg/kcpexisting/clients/clientset/versioned/fake/typed/example/v1beta1/testtype.go
+++ b/examples/pkg/kcpexisting/clients/clientset/versioned/fake/typed/example/v1beta1/testtype.go
@@ -39,8 +39,8 @@ import (
 	kcpexamplev1beta1 "acme.corp/pkg/kcp/clients/clientset/versioned/typed/example/v1beta1"
 )
 
-var testTypesResource = schema.GroupVersionResource{Group: "example", Version: "V1beta1", Resource: "testtypes"}
-var testTypesKind = schema.GroupVersionKind{Group: "example", Version: "V1beta1", Kind: "TestType"}
+var testTypesResource = schema.GroupVersionResource{Group: "example", Version: "v1beta1", Resource: "testtypes"}
+var testTypesKind = schema.GroupVersionKind{Group: "example", Version: "v1beta1", Kind: "TestType"}
 
 type testTypesClusterClient struct {
 	*kcptesting.Fake

--- a/examples/pkg/kcpexisting/clients/clientset/versioned/fake/typed/example/v2/clustertesttype.go
+++ b/examples/pkg/kcpexisting/clients/clientset/versioned/fake/typed/example/v2/clustertesttype.go
@@ -41,8 +41,8 @@ import (
 	examplev2client "acme.corp/pkg/generated/clientset/versioned/typed/example/v2"
 )
 
-var clusterTestTypesResource = schema.GroupVersionResource{Group: "example", Version: "V2", Resource: "clustertesttypes"}
-var clusterTestTypesKind = schema.GroupVersionKind{Group: "example", Version: "V2", Kind: "ClusterTestType"}
+var clusterTestTypesResource = schema.GroupVersionResource{Group: "example", Version: "v2", Resource: "clustertesttypes"}
+var clusterTestTypesKind = schema.GroupVersionKind{Group: "example", Version: "v2", Kind: "ClusterTestType"}
 
 type clusterTestTypesClusterClient struct {
 	*kcptesting.Fake

--- a/examples/pkg/kcpexisting/clients/clientset/versioned/fake/typed/example/v2/testtype.go
+++ b/examples/pkg/kcpexisting/clients/clientset/versioned/fake/typed/example/v2/testtype.go
@@ -42,8 +42,8 @@ import (
 	kcpexamplev2 "acme.corp/pkg/kcp/clients/clientset/versioned/typed/example/v2"
 )
 
-var testTypesResource = schema.GroupVersionResource{Group: "example", Version: "V2", Resource: "testtypes"}
-var testTypesKind = schema.GroupVersionKind{Group: "example", Version: "V2", Kind: "TestType"}
+var testTypesResource = schema.GroupVersionResource{Group: "example", Version: "v2", Resource: "testtypes"}
+var testTypesKind = schema.GroupVersionKind{Group: "example", Version: "v2", Kind: "TestType"}
 
 type testTypesClusterClient struct {
 	*kcptesting.Fake

--- a/examples/pkg/kcpexisting/clients/clientset/versioned/fake/typed/example3/v1/clustertesttype.go
+++ b/examples/pkg/kcpexisting/clients/clientset/versioned/fake/typed/example3/v1/clustertesttype.go
@@ -41,8 +41,8 @@ import (
 	example3v1client "acme.corp/pkg/generated/clientset/versioned/typed/example3/v1"
 )
 
-var clusterTestTypesResource = schema.GroupVersionResource{Group: "example3.some.corp", Version: "V1", Resource: "clustertesttypes"}
-var clusterTestTypesKind = schema.GroupVersionKind{Group: "example3.some.corp", Version: "V1", Kind: "ClusterTestType"}
+var clusterTestTypesResource = schema.GroupVersionResource{Group: "example3.some.corp", Version: "v1", Resource: "clustertesttypes"}
+var clusterTestTypesKind = schema.GroupVersionKind{Group: "example3.some.corp", Version: "v1", Kind: "ClusterTestType"}
 
 type clusterTestTypesClusterClient struct {
 	*kcptesting.Fake

--- a/examples/pkg/kcpexisting/clients/clientset/versioned/fake/typed/example3/v1/testtype.go
+++ b/examples/pkg/kcpexisting/clients/clientset/versioned/fake/typed/example3/v1/testtype.go
@@ -43,8 +43,8 @@ import (
 	kcpexample3v1 "acme.corp/pkg/kcp/clients/clientset/versioned/typed/example3/v1"
 )
 
-var testTypesResource = schema.GroupVersionResource{Group: "example3.some.corp", Version: "V1", Resource: "testtypes"}
-var testTypesKind = schema.GroupVersionKind{Group: "example3.some.corp", Version: "V1", Kind: "TestType"}
+var testTypesResource = schema.GroupVersionResource{Group: "example3.some.corp", Version: "v1", Resource: "testtypes"}
+var testTypesKind = schema.GroupVersionKind{Group: "example3.some.corp", Version: "v1", Kind: "TestType"}
 
 type testTypesClusterClient struct {
 	*kcptesting.Fake

--- a/examples/pkg/kcpexisting/clients/clientset/versioned/fake/typed/existinginterfaces/v1/clustertesttype.go
+++ b/examples/pkg/kcpexisting/clients/clientset/versioned/fake/typed/existinginterfaces/v1/clustertesttype.go
@@ -41,8 +41,8 @@ import (
 	existinginterfacesv1client "acme.corp/pkg/generated/clientset/versioned/typed/existinginterfaces/v1"
 )
 
-var clusterTestTypesResource = schema.GroupVersionResource{Group: "existinginterfaces.acme.corp", Version: "V1", Resource: "clustertesttypes"}
-var clusterTestTypesKind = schema.GroupVersionKind{Group: "existinginterfaces.acme.corp", Version: "V1", Kind: "ClusterTestType"}
+var clusterTestTypesResource = schema.GroupVersionResource{Group: "existinginterfaces.acme.corp", Version: "v1", Resource: "clustertesttypes"}
+var clusterTestTypesKind = schema.GroupVersionKind{Group: "existinginterfaces.acme.corp", Version: "v1", Kind: "ClusterTestType"}
 
 type clusterTestTypesClusterClient struct {
 	*kcptesting.Fake

--- a/examples/pkg/kcpexisting/clients/clientset/versioned/fake/typed/existinginterfaces/v1/testtype.go
+++ b/examples/pkg/kcpexisting/clients/clientset/versioned/fake/typed/existinginterfaces/v1/testtype.go
@@ -42,8 +42,8 @@ import (
 	kcpexistinginterfacesv1 "acme.corp/pkg/kcp/clients/clientset/versioned/typed/existinginterfaces/v1"
 )
 
-var testTypesResource = schema.GroupVersionResource{Group: "existinginterfaces.acme.corp", Version: "V1", Resource: "testtypes"}
-var testTypesKind = schema.GroupVersionKind{Group: "existinginterfaces.acme.corp", Version: "V1", Kind: "TestType"}
+var testTypesResource = schema.GroupVersionResource{Group: "existinginterfaces.acme.corp", Version: "v1", Resource: "testtypes"}
+var testTypesKind = schema.GroupVersionKind{Group: "existinginterfaces.acme.corp", Version: "v1", Kind: "TestType"}
 
 type testTypesClusterClient struct {
 	*kcptesting.Fake

--- a/examples/pkg/kcpexisting/clients/clientset/versioned/fake/typed/secondexample/v1/clustertesttype.go
+++ b/examples/pkg/kcpexisting/clients/clientset/versioned/fake/typed/secondexample/v1/clustertesttype.go
@@ -41,8 +41,8 @@ import (
 	secondexamplev1client "acme.corp/pkg/generated/clientset/versioned/typed/secondexample/v1"
 )
 
-var clusterTestTypesResource = schema.GroupVersionResource{Group: "secondexample", Version: "V1", Resource: "clustertesttypes"}
-var clusterTestTypesKind = schema.GroupVersionKind{Group: "secondexample", Version: "V1", Kind: "ClusterTestType"}
+var clusterTestTypesResource = schema.GroupVersionResource{Group: "secondexample", Version: "v1", Resource: "clustertesttypes"}
+var clusterTestTypesKind = schema.GroupVersionKind{Group: "secondexample", Version: "v1", Kind: "ClusterTestType"}
 
 type clusterTestTypesClusterClient struct {
 	*kcptesting.Fake

--- a/examples/pkg/kcpexisting/clients/clientset/versioned/fake/typed/secondexample/v1/testtype.go
+++ b/examples/pkg/kcpexisting/clients/clientset/versioned/fake/typed/secondexample/v1/testtype.go
@@ -42,8 +42,8 @@ import (
 	kcpsecondexamplev1 "acme.corp/pkg/kcp/clients/clientset/versioned/typed/secondexample/v1"
 )
 
-var testTypesResource = schema.GroupVersionResource{Group: "secondexample", Version: "V1", Resource: "testtypes"}
-var testTypesKind = schema.GroupVersionKind{Group: "secondexample", Version: "V1", Kind: "TestType"}
+var testTypesResource = schema.GroupVersionResource{Group: "secondexample", Version: "v1", Resource: "testtypes"}
+var testTypesKind = schema.GroupVersionKind{Group: "secondexample", Version: "v1", Kind: "TestType"}
 
 type testTypesClusterClient struct {
 	*kcptesting.Fake

--- a/examples/pkg/kcpexisting/clients/informers/example/v1/clustertesttype.go
+++ b/examples/pkg/kcpexisting/clients/informers/example/v1/clustertesttype.go
@@ -42,7 +42,7 @@ import (
 // ClusterTestTypeClusterInformer provides access to a shared informer and lister for
 // ClusterTestTypes.
 type ClusterTestTypeClusterInformer interface {
-	Informer() cache.SharedIndexInformer
+	Informer() kcpcache.ScopeableSharedIndexInformer
 	Lister() examplev1listers.ClusterTestTypeClusterLister
 }
 
@@ -54,14 +54,14 @@ type clusterTestTypeClusterInformer struct {
 // NewClusterTestTypeClusterInformer constructs a new informer for ClusterTestType type.
 // Always prefer using an informer factory to get a shared informer instead of getting an independent
 // one. This reduces memory footprint and number of connections to the server.
-func NewClusterTestTypeClusterInformer(client clientset.ClusterInterface, resyncPeriod time.Duration, indexers cache.Indexers) cache.SharedIndexInformer {
+func NewClusterTestTypeClusterInformer(client clientset.ClusterInterface, resyncPeriod time.Duration, indexers cache.Indexers) kcpcache.ScopeableSharedIndexInformer {
 	return NewFilteredClusterTestTypeClusterInformer(client, resyncPeriod, indexers, nil)
 }
 
 // NewFilteredClusterTestTypeClusterInformer constructs a new informer for ClusterTestType type.
 // Always prefer using an informer factory to get a shared informer instead of getting an independent
 // one. This reduces memory footprint and number of connections to the server.
-func NewFilteredClusterTestTypeClusterInformer(client clientset.ClusterInterface, resyncPeriod time.Duration, indexers cache.Indexers, tweakListOptions internalinterfaces.TweakListOptionsFunc) cache.SharedIndexInformer {
+func NewFilteredClusterTestTypeClusterInformer(client clientset.ClusterInterface, resyncPeriod time.Duration, indexers cache.Indexers, tweakListOptions internalinterfaces.TweakListOptionsFunc) kcpcache.ScopeableSharedIndexInformer {
 	return kcpinformers.NewSharedIndexInformer(
 		&cache.ListWatch{
 			ListFunc: func(options metav1.ListOptions) (runtime.Object, error) {
@@ -83,7 +83,7 @@ func NewFilteredClusterTestTypeClusterInformer(client clientset.ClusterInterface
 	)
 }
 
-func (f *clusterTestTypeClusterInformer) defaultInformer(client clientset.ClusterInterface, resyncPeriod time.Duration) cache.SharedIndexInformer {
+func (f *clusterTestTypeClusterInformer) defaultInformer(client clientset.ClusterInterface, resyncPeriod time.Duration) kcpcache.ScopeableSharedIndexInformer {
 	return NewFilteredClusterTestTypeClusterInformer(client, resyncPeriod, cache.Indexers{
 		kcpcache.ClusterIndexName: kcpcache.ClusterIndexFunc,
 	},
@@ -91,7 +91,7 @@ func (f *clusterTestTypeClusterInformer) defaultInformer(client clientset.Cluste
 	)
 }
 
-func (f *clusterTestTypeClusterInformer) Informer() cache.SharedIndexInformer {
+func (f *clusterTestTypeClusterInformer) Informer() kcpcache.ScopeableSharedIndexInformer {
 	return f.factory.InformerFor(&examplev1.ClusterTestType{}, f.defaultInformer)
 }
 

--- a/examples/pkg/kcpexisting/clients/informers/example/v1/testtype.go
+++ b/examples/pkg/kcpexisting/clients/informers/example/v1/testtype.go
@@ -42,7 +42,7 @@ import (
 // TestTypeClusterInformer provides access to a shared informer and lister for
 // TestTypes.
 type TestTypeClusterInformer interface {
-	Informer() cache.SharedIndexInformer
+	Informer() kcpcache.ScopeableSharedIndexInformer
 	Lister() examplev1listers.TestTypeClusterLister
 }
 
@@ -54,14 +54,14 @@ type testTypeClusterInformer struct {
 // NewTestTypeClusterInformer constructs a new informer for TestType type.
 // Always prefer using an informer factory to get a shared informer instead of getting an independent
 // one. This reduces memory footprint and number of connections to the server.
-func NewTestTypeClusterInformer(client clientset.ClusterInterface, resyncPeriod time.Duration, indexers cache.Indexers) cache.SharedIndexInformer {
+func NewTestTypeClusterInformer(client clientset.ClusterInterface, resyncPeriod time.Duration, indexers cache.Indexers) kcpcache.ScopeableSharedIndexInformer {
 	return NewFilteredTestTypeClusterInformer(client, resyncPeriod, indexers, nil)
 }
 
 // NewFilteredTestTypeClusterInformer constructs a new informer for TestType type.
 // Always prefer using an informer factory to get a shared informer instead of getting an independent
 // one. This reduces memory footprint and number of connections to the server.
-func NewFilteredTestTypeClusterInformer(client clientset.ClusterInterface, resyncPeriod time.Duration, indexers cache.Indexers, tweakListOptions internalinterfaces.TweakListOptionsFunc) cache.SharedIndexInformer {
+func NewFilteredTestTypeClusterInformer(client clientset.ClusterInterface, resyncPeriod time.Duration, indexers cache.Indexers, tweakListOptions internalinterfaces.TweakListOptionsFunc) kcpcache.ScopeableSharedIndexInformer {
 	return kcpinformers.NewSharedIndexInformer(
 		&cache.ListWatch{
 			ListFunc: func(options metav1.ListOptions) (runtime.Object, error) {
@@ -83,7 +83,7 @@ func NewFilteredTestTypeClusterInformer(client clientset.ClusterInterface, resyn
 	)
 }
 
-func (f *testTypeClusterInformer) defaultInformer(client clientset.ClusterInterface, resyncPeriod time.Duration) cache.SharedIndexInformer {
+func (f *testTypeClusterInformer) defaultInformer(client clientset.ClusterInterface, resyncPeriod time.Duration) kcpcache.ScopeableSharedIndexInformer {
 	return NewFilteredTestTypeClusterInformer(client, resyncPeriod, cache.Indexers{
 		kcpcache.ClusterIndexName:             kcpcache.ClusterIndexFunc,
 		kcpcache.ClusterAndNamespaceIndexName: kcpcache.ClusterAndNamespaceIndexFunc},
@@ -91,7 +91,7 @@ func (f *testTypeClusterInformer) defaultInformer(client clientset.ClusterInterf
 	)
 }
 
-func (f *testTypeClusterInformer) Informer() cache.SharedIndexInformer {
+func (f *testTypeClusterInformer) Informer() kcpcache.ScopeableSharedIndexInformer {
 	return f.factory.InformerFor(&examplev1.TestType{}, f.defaultInformer)
 }
 

--- a/examples/pkg/kcpexisting/clients/informers/example/v1alpha1/clustertesttype.go
+++ b/examples/pkg/kcpexisting/clients/informers/example/v1alpha1/clustertesttype.go
@@ -42,7 +42,7 @@ import (
 // ClusterTestTypeClusterInformer provides access to a shared informer and lister for
 // ClusterTestTypes.
 type ClusterTestTypeClusterInformer interface {
-	Informer() cache.SharedIndexInformer
+	Informer() kcpcache.ScopeableSharedIndexInformer
 	Lister() examplev1alpha1listers.ClusterTestTypeClusterLister
 }
 
@@ -54,14 +54,14 @@ type clusterTestTypeClusterInformer struct {
 // NewClusterTestTypeClusterInformer constructs a new informer for ClusterTestType type.
 // Always prefer using an informer factory to get a shared informer instead of getting an independent
 // one. This reduces memory footprint and number of connections to the server.
-func NewClusterTestTypeClusterInformer(client clientset.ClusterInterface, resyncPeriod time.Duration, indexers cache.Indexers) cache.SharedIndexInformer {
+func NewClusterTestTypeClusterInformer(client clientset.ClusterInterface, resyncPeriod time.Duration, indexers cache.Indexers) kcpcache.ScopeableSharedIndexInformer {
 	return NewFilteredClusterTestTypeClusterInformer(client, resyncPeriod, indexers, nil)
 }
 
 // NewFilteredClusterTestTypeClusterInformer constructs a new informer for ClusterTestType type.
 // Always prefer using an informer factory to get a shared informer instead of getting an independent
 // one. This reduces memory footprint and number of connections to the server.
-func NewFilteredClusterTestTypeClusterInformer(client clientset.ClusterInterface, resyncPeriod time.Duration, indexers cache.Indexers, tweakListOptions internalinterfaces.TweakListOptionsFunc) cache.SharedIndexInformer {
+func NewFilteredClusterTestTypeClusterInformer(client clientset.ClusterInterface, resyncPeriod time.Duration, indexers cache.Indexers, tweakListOptions internalinterfaces.TweakListOptionsFunc) kcpcache.ScopeableSharedIndexInformer {
 	return kcpinformers.NewSharedIndexInformer(
 		&cache.ListWatch{
 			ListFunc: func(options metav1.ListOptions) (runtime.Object, error) {
@@ -83,7 +83,7 @@ func NewFilteredClusterTestTypeClusterInformer(client clientset.ClusterInterface
 	)
 }
 
-func (f *clusterTestTypeClusterInformer) defaultInformer(client clientset.ClusterInterface, resyncPeriod time.Duration) cache.SharedIndexInformer {
+func (f *clusterTestTypeClusterInformer) defaultInformer(client clientset.ClusterInterface, resyncPeriod time.Duration) kcpcache.ScopeableSharedIndexInformer {
 	return NewFilteredClusterTestTypeClusterInformer(client, resyncPeriod, cache.Indexers{
 		kcpcache.ClusterIndexName: kcpcache.ClusterIndexFunc,
 	},
@@ -91,7 +91,7 @@ func (f *clusterTestTypeClusterInformer) defaultInformer(client clientset.Cluste
 	)
 }
 
-func (f *clusterTestTypeClusterInformer) Informer() cache.SharedIndexInformer {
+func (f *clusterTestTypeClusterInformer) Informer() kcpcache.ScopeableSharedIndexInformer {
 	return f.factory.InformerFor(&examplev1alpha1.ClusterTestType{}, f.defaultInformer)
 }
 

--- a/examples/pkg/kcpexisting/clients/informers/example/v1alpha1/testtype.go
+++ b/examples/pkg/kcpexisting/clients/informers/example/v1alpha1/testtype.go
@@ -42,7 +42,7 @@ import (
 // TestTypeClusterInformer provides access to a shared informer and lister for
 // TestTypes.
 type TestTypeClusterInformer interface {
-	Informer() cache.SharedIndexInformer
+	Informer() kcpcache.ScopeableSharedIndexInformer
 	Lister() examplev1alpha1listers.TestTypeClusterLister
 }
 
@@ -54,14 +54,14 @@ type testTypeClusterInformer struct {
 // NewTestTypeClusterInformer constructs a new informer for TestType type.
 // Always prefer using an informer factory to get a shared informer instead of getting an independent
 // one. This reduces memory footprint and number of connections to the server.
-func NewTestTypeClusterInformer(client clientset.ClusterInterface, resyncPeriod time.Duration, indexers cache.Indexers) cache.SharedIndexInformer {
+func NewTestTypeClusterInformer(client clientset.ClusterInterface, resyncPeriod time.Duration, indexers cache.Indexers) kcpcache.ScopeableSharedIndexInformer {
 	return NewFilteredTestTypeClusterInformer(client, resyncPeriod, indexers, nil)
 }
 
 // NewFilteredTestTypeClusterInformer constructs a new informer for TestType type.
 // Always prefer using an informer factory to get a shared informer instead of getting an independent
 // one. This reduces memory footprint and number of connections to the server.
-func NewFilteredTestTypeClusterInformer(client clientset.ClusterInterface, resyncPeriod time.Duration, indexers cache.Indexers, tweakListOptions internalinterfaces.TweakListOptionsFunc) cache.SharedIndexInformer {
+func NewFilteredTestTypeClusterInformer(client clientset.ClusterInterface, resyncPeriod time.Duration, indexers cache.Indexers, tweakListOptions internalinterfaces.TweakListOptionsFunc) kcpcache.ScopeableSharedIndexInformer {
 	return kcpinformers.NewSharedIndexInformer(
 		&cache.ListWatch{
 			ListFunc: func(options metav1.ListOptions) (runtime.Object, error) {
@@ -83,7 +83,7 @@ func NewFilteredTestTypeClusterInformer(client clientset.ClusterInterface, resyn
 	)
 }
 
-func (f *testTypeClusterInformer) defaultInformer(client clientset.ClusterInterface, resyncPeriod time.Duration) cache.SharedIndexInformer {
+func (f *testTypeClusterInformer) defaultInformer(client clientset.ClusterInterface, resyncPeriod time.Duration) kcpcache.ScopeableSharedIndexInformer {
 	return NewFilteredTestTypeClusterInformer(client, resyncPeriod, cache.Indexers{
 		kcpcache.ClusterIndexName:             kcpcache.ClusterIndexFunc,
 		kcpcache.ClusterAndNamespaceIndexName: kcpcache.ClusterAndNamespaceIndexFunc},
@@ -91,7 +91,7 @@ func (f *testTypeClusterInformer) defaultInformer(client clientset.ClusterInterf
 	)
 }
 
-func (f *testTypeClusterInformer) Informer() cache.SharedIndexInformer {
+func (f *testTypeClusterInformer) Informer() kcpcache.ScopeableSharedIndexInformer {
 	return f.factory.InformerFor(&examplev1alpha1.TestType{}, f.defaultInformer)
 }
 

--- a/examples/pkg/kcpexisting/clients/informers/example/v1beta1/clustertesttype.go
+++ b/examples/pkg/kcpexisting/clients/informers/example/v1beta1/clustertesttype.go
@@ -42,7 +42,7 @@ import (
 // ClusterTestTypeClusterInformer provides access to a shared informer and lister for
 // ClusterTestTypes.
 type ClusterTestTypeClusterInformer interface {
-	Informer() cache.SharedIndexInformer
+	Informer() kcpcache.ScopeableSharedIndexInformer
 	Lister() examplev1beta1listers.ClusterTestTypeClusterLister
 }
 
@@ -54,14 +54,14 @@ type clusterTestTypeClusterInformer struct {
 // NewClusterTestTypeClusterInformer constructs a new informer for ClusterTestType type.
 // Always prefer using an informer factory to get a shared informer instead of getting an independent
 // one. This reduces memory footprint and number of connections to the server.
-func NewClusterTestTypeClusterInformer(client clientset.ClusterInterface, resyncPeriod time.Duration, indexers cache.Indexers) cache.SharedIndexInformer {
+func NewClusterTestTypeClusterInformer(client clientset.ClusterInterface, resyncPeriod time.Duration, indexers cache.Indexers) kcpcache.ScopeableSharedIndexInformer {
 	return NewFilteredClusterTestTypeClusterInformer(client, resyncPeriod, indexers, nil)
 }
 
 // NewFilteredClusterTestTypeClusterInformer constructs a new informer for ClusterTestType type.
 // Always prefer using an informer factory to get a shared informer instead of getting an independent
 // one. This reduces memory footprint and number of connections to the server.
-func NewFilteredClusterTestTypeClusterInformer(client clientset.ClusterInterface, resyncPeriod time.Duration, indexers cache.Indexers, tweakListOptions internalinterfaces.TweakListOptionsFunc) cache.SharedIndexInformer {
+func NewFilteredClusterTestTypeClusterInformer(client clientset.ClusterInterface, resyncPeriod time.Duration, indexers cache.Indexers, tweakListOptions internalinterfaces.TweakListOptionsFunc) kcpcache.ScopeableSharedIndexInformer {
 	return kcpinformers.NewSharedIndexInformer(
 		&cache.ListWatch{
 			ListFunc: func(options metav1.ListOptions) (runtime.Object, error) {
@@ -83,7 +83,7 @@ func NewFilteredClusterTestTypeClusterInformer(client clientset.ClusterInterface
 	)
 }
 
-func (f *clusterTestTypeClusterInformer) defaultInformer(client clientset.ClusterInterface, resyncPeriod time.Duration) cache.SharedIndexInformer {
+func (f *clusterTestTypeClusterInformer) defaultInformer(client clientset.ClusterInterface, resyncPeriod time.Duration) kcpcache.ScopeableSharedIndexInformer {
 	return NewFilteredClusterTestTypeClusterInformer(client, resyncPeriod, cache.Indexers{
 		kcpcache.ClusterIndexName: kcpcache.ClusterIndexFunc,
 	},
@@ -91,7 +91,7 @@ func (f *clusterTestTypeClusterInformer) defaultInformer(client clientset.Cluste
 	)
 }
 
-func (f *clusterTestTypeClusterInformer) Informer() cache.SharedIndexInformer {
+func (f *clusterTestTypeClusterInformer) Informer() kcpcache.ScopeableSharedIndexInformer {
 	return f.factory.InformerFor(&examplev1beta1.ClusterTestType{}, f.defaultInformer)
 }
 

--- a/examples/pkg/kcpexisting/clients/informers/example/v2/clustertesttype.go
+++ b/examples/pkg/kcpexisting/clients/informers/example/v2/clustertesttype.go
@@ -42,7 +42,7 @@ import (
 // ClusterTestTypeClusterInformer provides access to a shared informer and lister for
 // ClusterTestTypes.
 type ClusterTestTypeClusterInformer interface {
-	Informer() cache.SharedIndexInformer
+	Informer() kcpcache.ScopeableSharedIndexInformer
 	Lister() examplev2listers.ClusterTestTypeClusterLister
 }
 
@@ -54,14 +54,14 @@ type clusterTestTypeClusterInformer struct {
 // NewClusterTestTypeClusterInformer constructs a new informer for ClusterTestType type.
 // Always prefer using an informer factory to get a shared informer instead of getting an independent
 // one. This reduces memory footprint and number of connections to the server.
-func NewClusterTestTypeClusterInformer(client clientset.ClusterInterface, resyncPeriod time.Duration, indexers cache.Indexers) cache.SharedIndexInformer {
+func NewClusterTestTypeClusterInformer(client clientset.ClusterInterface, resyncPeriod time.Duration, indexers cache.Indexers) kcpcache.ScopeableSharedIndexInformer {
 	return NewFilteredClusterTestTypeClusterInformer(client, resyncPeriod, indexers, nil)
 }
 
 // NewFilteredClusterTestTypeClusterInformer constructs a new informer for ClusterTestType type.
 // Always prefer using an informer factory to get a shared informer instead of getting an independent
 // one. This reduces memory footprint and number of connections to the server.
-func NewFilteredClusterTestTypeClusterInformer(client clientset.ClusterInterface, resyncPeriod time.Duration, indexers cache.Indexers, tweakListOptions internalinterfaces.TweakListOptionsFunc) cache.SharedIndexInformer {
+func NewFilteredClusterTestTypeClusterInformer(client clientset.ClusterInterface, resyncPeriod time.Duration, indexers cache.Indexers, tweakListOptions internalinterfaces.TweakListOptionsFunc) kcpcache.ScopeableSharedIndexInformer {
 	return kcpinformers.NewSharedIndexInformer(
 		&cache.ListWatch{
 			ListFunc: func(options metav1.ListOptions) (runtime.Object, error) {
@@ -83,7 +83,7 @@ func NewFilteredClusterTestTypeClusterInformer(client clientset.ClusterInterface
 	)
 }
 
-func (f *clusterTestTypeClusterInformer) defaultInformer(client clientset.ClusterInterface, resyncPeriod time.Duration) cache.SharedIndexInformer {
+func (f *clusterTestTypeClusterInformer) defaultInformer(client clientset.ClusterInterface, resyncPeriod time.Duration) kcpcache.ScopeableSharedIndexInformer {
 	return NewFilteredClusterTestTypeClusterInformer(client, resyncPeriod, cache.Indexers{
 		kcpcache.ClusterIndexName: kcpcache.ClusterIndexFunc,
 	},
@@ -91,7 +91,7 @@ func (f *clusterTestTypeClusterInformer) defaultInformer(client clientset.Cluste
 	)
 }
 
-func (f *clusterTestTypeClusterInformer) Informer() cache.SharedIndexInformer {
+func (f *clusterTestTypeClusterInformer) Informer() kcpcache.ScopeableSharedIndexInformer {
 	return f.factory.InformerFor(&examplev2.ClusterTestType{}, f.defaultInformer)
 }
 

--- a/examples/pkg/kcpexisting/clients/informers/example/v2/testtype.go
+++ b/examples/pkg/kcpexisting/clients/informers/example/v2/testtype.go
@@ -42,7 +42,7 @@ import (
 // TestTypeClusterInformer provides access to a shared informer and lister for
 // TestTypes.
 type TestTypeClusterInformer interface {
-	Informer() cache.SharedIndexInformer
+	Informer() kcpcache.ScopeableSharedIndexInformer
 	Lister() examplev2listers.TestTypeClusterLister
 }
 
@@ -54,14 +54,14 @@ type testTypeClusterInformer struct {
 // NewTestTypeClusterInformer constructs a new informer for TestType type.
 // Always prefer using an informer factory to get a shared informer instead of getting an independent
 // one. This reduces memory footprint and number of connections to the server.
-func NewTestTypeClusterInformer(client clientset.ClusterInterface, resyncPeriod time.Duration, indexers cache.Indexers) cache.SharedIndexInformer {
+func NewTestTypeClusterInformer(client clientset.ClusterInterface, resyncPeriod time.Duration, indexers cache.Indexers) kcpcache.ScopeableSharedIndexInformer {
 	return NewFilteredTestTypeClusterInformer(client, resyncPeriod, indexers, nil)
 }
 
 // NewFilteredTestTypeClusterInformer constructs a new informer for TestType type.
 // Always prefer using an informer factory to get a shared informer instead of getting an independent
 // one. This reduces memory footprint and number of connections to the server.
-func NewFilteredTestTypeClusterInformer(client clientset.ClusterInterface, resyncPeriod time.Duration, indexers cache.Indexers, tweakListOptions internalinterfaces.TweakListOptionsFunc) cache.SharedIndexInformer {
+func NewFilteredTestTypeClusterInformer(client clientset.ClusterInterface, resyncPeriod time.Duration, indexers cache.Indexers, tweakListOptions internalinterfaces.TweakListOptionsFunc) kcpcache.ScopeableSharedIndexInformer {
 	return kcpinformers.NewSharedIndexInformer(
 		&cache.ListWatch{
 			ListFunc: func(options metav1.ListOptions) (runtime.Object, error) {
@@ -83,7 +83,7 @@ func NewFilteredTestTypeClusterInformer(client clientset.ClusterInterface, resyn
 	)
 }
 
-func (f *testTypeClusterInformer) defaultInformer(client clientset.ClusterInterface, resyncPeriod time.Duration) cache.SharedIndexInformer {
+func (f *testTypeClusterInformer) defaultInformer(client clientset.ClusterInterface, resyncPeriod time.Duration) kcpcache.ScopeableSharedIndexInformer {
 	return NewFilteredTestTypeClusterInformer(client, resyncPeriod, cache.Indexers{
 		kcpcache.ClusterIndexName:             kcpcache.ClusterIndexFunc,
 		kcpcache.ClusterAndNamespaceIndexName: kcpcache.ClusterAndNamespaceIndexFunc},
@@ -91,7 +91,7 @@ func (f *testTypeClusterInformer) defaultInformer(client clientset.ClusterInterf
 	)
 }
 
-func (f *testTypeClusterInformer) Informer() cache.SharedIndexInformer {
+func (f *testTypeClusterInformer) Informer() kcpcache.ScopeableSharedIndexInformer {
 	return f.factory.InformerFor(&examplev2.TestType{}, f.defaultInformer)
 }
 

--- a/examples/pkg/kcpexisting/clients/informers/example3/v1/clustertesttype.go
+++ b/examples/pkg/kcpexisting/clients/informers/example3/v1/clustertesttype.go
@@ -42,7 +42,7 @@ import (
 // ClusterTestTypeClusterInformer provides access to a shared informer and lister for
 // ClusterTestTypes.
 type ClusterTestTypeClusterInformer interface {
-	Informer() cache.SharedIndexInformer
+	Informer() kcpcache.ScopeableSharedIndexInformer
 	Lister() example3v1listers.ClusterTestTypeClusterLister
 }
 
@@ -54,14 +54,14 @@ type clusterTestTypeClusterInformer struct {
 // NewClusterTestTypeClusterInformer constructs a new informer for ClusterTestType type.
 // Always prefer using an informer factory to get a shared informer instead of getting an independent
 // one. This reduces memory footprint and number of connections to the server.
-func NewClusterTestTypeClusterInformer(client clientset.ClusterInterface, resyncPeriod time.Duration, indexers cache.Indexers) cache.SharedIndexInformer {
+func NewClusterTestTypeClusterInformer(client clientset.ClusterInterface, resyncPeriod time.Duration, indexers cache.Indexers) kcpcache.ScopeableSharedIndexInformer {
 	return NewFilteredClusterTestTypeClusterInformer(client, resyncPeriod, indexers, nil)
 }
 
 // NewFilteredClusterTestTypeClusterInformer constructs a new informer for ClusterTestType type.
 // Always prefer using an informer factory to get a shared informer instead of getting an independent
 // one. This reduces memory footprint and number of connections to the server.
-func NewFilteredClusterTestTypeClusterInformer(client clientset.ClusterInterface, resyncPeriod time.Duration, indexers cache.Indexers, tweakListOptions internalinterfaces.TweakListOptionsFunc) cache.SharedIndexInformer {
+func NewFilteredClusterTestTypeClusterInformer(client clientset.ClusterInterface, resyncPeriod time.Duration, indexers cache.Indexers, tweakListOptions internalinterfaces.TweakListOptionsFunc) kcpcache.ScopeableSharedIndexInformer {
 	return kcpinformers.NewSharedIndexInformer(
 		&cache.ListWatch{
 			ListFunc: func(options metav1.ListOptions) (runtime.Object, error) {
@@ -83,7 +83,7 @@ func NewFilteredClusterTestTypeClusterInformer(client clientset.ClusterInterface
 	)
 }
 
-func (f *clusterTestTypeClusterInformer) defaultInformer(client clientset.ClusterInterface, resyncPeriod time.Duration) cache.SharedIndexInformer {
+func (f *clusterTestTypeClusterInformer) defaultInformer(client clientset.ClusterInterface, resyncPeriod time.Duration) kcpcache.ScopeableSharedIndexInformer {
 	return NewFilteredClusterTestTypeClusterInformer(client, resyncPeriod, cache.Indexers{
 		kcpcache.ClusterIndexName: kcpcache.ClusterIndexFunc,
 	},
@@ -91,7 +91,7 @@ func (f *clusterTestTypeClusterInformer) defaultInformer(client clientset.Cluste
 	)
 }
 
-func (f *clusterTestTypeClusterInformer) Informer() cache.SharedIndexInformer {
+func (f *clusterTestTypeClusterInformer) Informer() kcpcache.ScopeableSharedIndexInformer {
 	return f.factory.InformerFor(&example3v1.ClusterTestType{}, f.defaultInformer)
 }
 

--- a/examples/pkg/kcpexisting/clients/informers/example3/v1/testtype.go
+++ b/examples/pkg/kcpexisting/clients/informers/example3/v1/testtype.go
@@ -42,7 +42,7 @@ import (
 // TestTypeClusterInformer provides access to a shared informer and lister for
 // TestTypes.
 type TestTypeClusterInformer interface {
-	Informer() cache.SharedIndexInformer
+	Informer() kcpcache.ScopeableSharedIndexInformer
 	Lister() example3v1listers.TestTypeClusterLister
 }
 
@@ -54,14 +54,14 @@ type testTypeClusterInformer struct {
 // NewTestTypeClusterInformer constructs a new informer for TestType type.
 // Always prefer using an informer factory to get a shared informer instead of getting an independent
 // one. This reduces memory footprint and number of connections to the server.
-func NewTestTypeClusterInformer(client clientset.ClusterInterface, resyncPeriod time.Duration, indexers cache.Indexers) cache.SharedIndexInformer {
+func NewTestTypeClusterInformer(client clientset.ClusterInterface, resyncPeriod time.Duration, indexers cache.Indexers) kcpcache.ScopeableSharedIndexInformer {
 	return NewFilteredTestTypeClusterInformer(client, resyncPeriod, indexers, nil)
 }
 
 // NewFilteredTestTypeClusterInformer constructs a new informer for TestType type.
 // Always prefer using an informer factory to get a shared informer instead of getting an independent
 // one. This reduces memory footprint and number of connections to the server.
-func NewFilteredTestTypeClusterInformer(client clientset.ClusterInterface, resyncPeriod time.Duration, indexers cache.Indexers, tweakListOptions internalinterfaces.TweakListOptionsFunc) cache.SharedIndexInformer {
+func NewFilteredTestTypeClusterInformer(client clientset.ClusterInterface, resyncPeriod time.Duration, indexers cache.Indexers, tweakListOptions internalinterfaces.TweakListOptionsFunc) kcpcache.ScopeableSharedIndexInformer {
 	return kcpinformers.NewSharedIndexInformer(
 		&cache.ListWatch{
 			ListFunc: func(options metav1.ListOptions) (runtime.Object, error) {
@@ -83,7 +83,7 @@ func NewFilteredTestTypeClusterInformer(client clientset.ClusterInterface, resyn
 	)
 }
 
-func (f *testTypeClusterInformer) defaultInformer(client clientset.ClusterInterface, resyncPeriod time.Duration) cache.SharedIndexInformer {
+func (f *testTypeClusterInformer) defaultInformer(client clientset.ClusterInterface, resyncPeriod time.Duration) kcpcache.ScopeableSharedIndexInformer {
 	return NewFilteredTestTypeClusterInformer(client, resyncPeriod, cache.Indexers{
 		kcpcache.ClusterIndexName:             kcpcache.ClusterIndexFunc,
 		kcpcache.ClusterAndNamespaceIndexName: kcpcache.ClusterAndNamespaceIndexFunc},
@@ -91,7 +91,7 @@ func (f *testTypeClusterInformer) defaultInformer(client clientset.ClusterInterf
 	)
 }
 
-func (f *testTypeClusterInformer) Informer() cache.SharedIndexInformer {
+func (f *testTypeClusterInformer) Informer() kcpcache.ScopeableSharedIndexInformer {
 	return f.factory.InformerFor(&example3v1.TestType{}, f.defaultInformer)
 }
 

--- a/examples/pkg/kcpexisting/clients/informers/existinginterfaces/v1/clustertesttype.go
+++ b/examples/pkg/kcpexisting/clients/informers/existinginterfaces/v1/clustertesttype.go
@@ -42,7 +42,7 @@ import (
 // ClusterTestTypeClusterInformer provides access to a shared informer and lister for
 // ClusterTestTypes.
 type ClusterTestTypeClusterInformer interface {
-	Informer() cache.SharedIndexInformer
+	Informer() kcpcache.ScopeableSharedIndexInformer
 	Lister() existinginterfacesv1listers.ClusterTestTypeClusterLister
 }
 
@@ -54,14 +54,14 @@ type clusterTestTypeClusterInformer struct {
 // NewClusterTestTypeClusterInformer constructs a new informer for ClusterTestType type.
 // Always prefer using an informer factory to get a shared informer instead of getting an independent
 // one. This reduces memory footprint and number of connections to the server.
-func NewClusterTestTypeClusterInformer(client clientset.ClusterInterface, resyncPeriod time.Duration, indexers cache.Indexers) cache.SharedIndexInformer {
+func NewClusterTestTypeClusterInformer(client clientset.ClusterInterface, resyncPeriod time.Duration, indexers cache.Indexers) kcpcache.ScopeableSharedIndexInformer {
 	return NewFilteredClusterTestTypeClusterInformer(client, resyncPeriod, indexers, nil)
 }
 
 // NewFilteredClusterTestTypeClusterInformer constructs a new informer for ClusterTestType type.
 // Always prefer using an informer factory to get a shared informer instead of getting an independent
 // one. This reduces memory footprint and number of connections to the server.
-func NewFilteredClusterTestTypeClusterInformer(client clientset.ClusterInterface, resyncPeriod time.Duration, indexers cache.Indexers, tweakListOptions internalinterfaces.TweakListOptionsFunc) cache.SharedIndexInformer {
+func NewFilteredClusterTestTypeClusterInformer(client clientset.ClusterInterface, resyncPeriod time.Duration, indexers cache.Indexers, tweakListOptions internalinterfaces.TweakListOptionsFunc) kcpcache.ScopeableSharedIndexInformer {
 	return kcpinformers.NewSharedIndexInformer(
 		&cache.ListWatch{
 			ListFunc: func(options metav1.ListOptions) (runtime.Object, error) {
@@ -83,7 +83,7 @@ func NewFilteredClusterTestTypeClusterInformer(client clientset.ClusterInterface
 	)
 }
 
-func (f *clusterTestTypeClusterInformer) defaultInformer(client clientset.ClusterInterface, resyncPeriod time.Duration) cache.SharedIndexInformer {
+func (f *clusterTestTypeClusterInformer) defaultInformer(client clientset.ClusterInterface, resyncPeriod time.Duration) kcpcache.ScopeableSharedIndexInformer {
 	return NewFilteredClusterTestTypeClusterInformer(client, resyncPeriod, cache.Indexers{
 		kcpcache.ClusterIndexName: kcpcache.ClusterIndexFunc,
 	},
@@ -91,7 +91,7 @@ func (f *clusterTestTypeClusterInformer) defaultInformer(client clientset.Cluste
 	)
 }
 
-func (f *clusterTestTypeClusterInformer) Informer() cache.SharedIndexInformer {
+func (f *clusterTestTypeClusterInformer) Informer() kcpcache.ScopeableSharedIndexInformer {
 	return f.factory.InformerFor(&existinginterfacesv1.ClusterTestType{}, f.defaultInformer)
 }
 

--- a/examples/pkg/kcpexisting/clients/informers/existinginterfaces/v1/testtype.go
+++ b/examples/pkg/kcpexisting/clients/informers/existinginterfaces/v1/testtype.go
@@ -42,7 +42,7 @@ import (
 // TestTypeClusterInformer provides access to a shared informer and lister for
 // TestTypes.
 type TestTypeClusterInformer interface {
-	Informer() cache.SharedIndexInformer
+	Informer() kcpcache.ScopeableSharedIndexInformer
 	Lister() existinginterfacesv1listers.TestTypeClusterLister
 }
 
@@ -54,14 +54,14 @@ type testTypeClusterInformer struct {
 // NewTestTypeClusterInformer constructs a new informer for TestType type.
 // Always prefer using an informer factory to get a shared informer instead of getting an independent
 // one. This reduces memory footprint and number of connections to the server.
-func NewTestTypeClusterInformer(client clientset.ClusterInterface, resyncPeriod time.Duration, indexers cache.Indexers) cache.SharedIndexInformer {
+func NewTestTypeClusterInformer(client clientset.ClusterInterface, resyncPeriod time.Duration, indexers cache.Indexers) kcpcache.ScopeableSharedIndexInformer {
 	return NewFilteredTestTypeClusterInformer(client, resyncPeriod, indexers, nil)
 }
 
 // NewFilteredTestTypeClusterInformer constructs a new informer for TestType type.
 // Always prefer using an informer factory to get a shared informer instead of getting an independent
 // one. This reduces memory footprint and number of connections to the server.
-func NewFilteredTestTypeClusterInformer(client clientset.ClusterInterface, resyncPeriod time.Duration, indexers cache.Indexers, tweakListOptions internalinterfaces.TweakListOptionsFunc) cache.SharedIndexInformer {
+func NewFilteredTestTypeClusterInformer(client clientset.ClusterInterface, resyncPeriod time.Duration, indexers cache.Indexers, tweakListOptions internalinterfaces.TweakListOptionsFunc) kcpcache.ScopeableSharedIndexInformer {
 	return kcpinformers.NewSharedIndexInformer(
 		&cache.ListWatch{
 			ListFunc: func(options metav1.ListOptions) (runtime.Object, error) {
@@ -83,7 +83,7 @@ func NewFilteredTestTypeClusterInformer(client clientset.ClusterInterface, resyn
 	)
 }
 
-func (f *testTypeClusterInformer) defaultInformer(client clientset.ClusterInterface, resyncPeriod time.Duration) cache.SharedIndexInformer {
+func (f *testTypeClusterInformer) defaultInformer(client clientset.ClusterInterface, resyncPeriod time.Duration) kcpcache.ScopeableSharedIndexInformer {
 	return NewFilteredTestTypeClusterInformer(client, resyncPeriod, cache.Indexers{
 		kcpcache.ClusterIndexName:             kcpcache.ClusterIndexFunc,
 		kcpcache.ClusterAndNamespaceIndexName: kcpcache.ClusterAndNamespaceIndexFunc},
@@ -91,7 +91,7 @@ func (f *testTypeClusterInformer) defaultInformer(client clientset.ClusterInterf
 	)
 }
 
-func (f *testTypeClusterInformer) Informer() cache.SharedIndexInformer {
+func (f *testTypeClusterInformer) Informer() kcpcache.ScopeableSharedIndexInformer {
 	return f.factory.InformerFor(&existinginterfacesv1.TestType{}, f.defaultInformer)
 }
 

--- a/examples/pkg/kcpexisting/clients/informers/factory.go
+++ b/examples/pkg/kcpexisting/clients/informers/factory.go
@@ -26,6 +26,8 @@ import (
 	"sync"
 	"time"
 
+	kcpcache "github.com/kcp-dev/apimachinery/pkg/cache"
+
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/runtime/schema"
@@ -49,7 +51,7 @@ type sharedInformerFactory struct {
 	defaultResync    time.Duration
 	customResync     map[reflect.Type]time.Duration
 
-	informers map[reflect.Type]cache.SharedIndexInformer
+	informers map[reflect.Type]kcpcache.ScopeableSharedIndexInformer
 	// startedInformers is used for tracking which informers have been started.
 	// This allows Start() to be called multiple times safely.
 	startedInformers map[reflect.Type]bool
@@ -83,7 +85,7 @@ func NewSharedInformerFactoryWithOptions(client clientset.ClusterInterface, defa
 	factory := &sharedInformerFactory{
 		client:           client,
 		defaultResync:    defaultResync,
-		informers:        make(map[reflect.Type]cache.SharedIndexInformer),
+		informers:        make(map[reflect.Type]kcpcache.ScopeableSharedIndexInformer),
 		startedInformers: make(map[reflect.Type]bool),
 		customResync:     make(map[reflect.Type]time.Duration),
 	}
@@ -111,11 +113,11 @@ func (f *sharedInformerFactory) Start(stopCh <-chan struct{}) {
 
 // WaitForCacheSync waits for all started informers' cache were synced.
 func (f *sharedInformerFactory) WaitForCacheSync(stopCh <-chan struct{}) map[reflect.Type]bool {
-	informers := func() map[reflect.Type]cache.SharedIndexInformer {
+	informers := func() map[reflect.Type]kcpcache.ScopeableSharedIndexInformer {
 		f.lock.Lock()
 		defer f.lock.Unlock()
 
-		informers := map[reflect.Type]cache.SharedIndexInformer{}
+		informers := map[reflect.Type]kcpcache.ScopeableSharedIndexInformer{}
 		for informerType, informer := range f.informers {
 			if f.startedInformers[informerType] {
 				informers[informerType] = informer
@@ -133,7 +135,7 @@ func (f *sharedInformerFactory) WaitForCacheSync(stopCh <-chan struct{}) map[ref
 
 // InternalInformerFor returns the SharedIndexInformer for obj using an internal
 // client.
-func (f *sharedInformerFactory) InformerFor(obj runtime.Object, newFunc internalinterfaces.NewInformerFunc) cache.SharedIndexInformer {
+func (f *sharedInformerFactory) InformerFor(obj runtime.Object, newFunc internalinterfaces.NewInformerFunc) kcpcache.ScopeableSharedIndexInformer {
 	f.lock.Lock()
 	defer f.lock.Unlock()
 

--- a/examples/pkg/kcpexisting/clients/informers/generic.go
+++ b/examples/pkg/kcpexisting/clients/informers/generic.go
@@ -27,7 +27,6 @@ import (
 	kcpcache "github.com/kcp-dev/apimachinery/pkg/cache"
 
 	"k8s.io/apimachinery/pkg/runtime/schema"
-	"k8s.io/client-go/tools/cache"
 
 	examplev1 "acme.corp/pkg/apis/example/v1"
 	examplev1alpha1 "acme.corp/pkg/apis/example/v1alpha1"
@@ -39,17 +38,17 @@ import (
 )
 
 type GenericClusterInformer interface {
-	Informer() cache.SharedIndexInformer
+	Informer() kcpcache.ScopeableSharedIndexInformer
 	Lister() kcpcache.GenericClusterLister
 }
 
 type genericClusterInformer struct {
-	informer cache.SharedIndexInformer
+	informer kcpcache.ScopeableSharedIndexInformer
 	resource schema.GroupResource
 }
 
 // Informer returns the SharedIndexInformer.
-func (f *genericClusterInformer) Informer() cache.SharedIndexInformer {
+func (f *genericClusterInformer) Informer() kcpcache.ScopeableSharedIndexInformer {
 	return f.informer
 }
 

--- a/examples/pkg/kcpexisting/clients/informers/internalinterfaces/factory_interfaces.go
+++ b/examples/pkg/kcpexisting/clients/informers/internalinterfaces/factory_interfaces.go
@@ -24,20 +24,21 @@ package internalinterfaces
 import (
 	time "time"
 
+	kcpcache "github.com/kcp-dev/apimachinery/pkg/cache"
+
 	v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	runtime "k8s.io/apimachinery/pkg/runtime"
-	cache "k8s.io/client-go/tools/cache"
 
 	client "acme.corp/pkg/kcp/clients/clientset/versioned"
 )
 
-// NewInformerFunc takes client.ClusterInterface and time.Duration to return a SharedIndexInformer.
-type NewInformerFunc func(client.ClusterInterface, time.Duration) cache.SharedIndexInformer
+// NewInformerFunc takes client.ClusterInterface and time.Duration to return a ScopeableSharedIndexInformer.
+type NewInformerFunc func(client.ClusterInterface, time.Duration) kcpcache.ScopeableSharedIndexInformer
 
 // SharedInformerFactory a small interface to allow for adding an informer without an import cycle
 type SharedInformerFactory interface {
 	Start(stopCh <-chan struct{})
-	InformerFor(obj runtime.Object, newFunc NewInformerFunc) cache.SharedIndexInformer
+	InformerFor(obj runtime.Object, newFunc NewInformerFunc) kcpcache.ScopeableSharedIndexInformer
 }
 
 // TweakListOptionsFunc is a function that transforms a v1.ListOptions.

--- a/examples/pkg/kcpexisting/clients/informers/secondexample/v1/clustertesttype.go
+++ b/examples/pkg/kcpexisting/clients/informers/secondexample/v1/clustertesttype.go
@@ -42,7 +42,7 @@ import (
 // ClusterTestTypeClusterInformer provides access to a shared informer and lister for
 // ClusterTestTypes.
 type ClusterTestTypeClusterInformer interface {
-	Informer() cache.SharedIndexInformer
+	Informer() kcpcache.ScopeableSharedIndexInformer
 	Lister() secondexamplev1listers.ClusterTestTypeClusterLister
 }
 
@@ -54,14 +54,14 @@ type clusterTestTypeClusterInformer struct {
 // NewClusterTestTypeClusterInformer constructs a new informer for ClusterTestType type.
 // Always prefer using an informer factory to get a shared informer instead of getting an independent
 // one. This reduces memory footprint and number of connections to the server.
-func NewClusterTestTypeClusterInformer(client clientset.ClusterInterface, resyncPeriod time.Duration, indexers cache.Indexers) cache.SharedIndexInformer {
+func NewClusterTestTypeClusterInformer(client clientset.ClusterInterface, resyncPeriod time.Duration, indexers cache.Indexers) kcpcache.ScopeableSharedIndexInformer {
 	return NewFilteredClusterTestTypeClusterInformer(client, resyncPeriod, indexers, nil)
 }
 
 // NewFilteredClusterTestTypeClusterInformer constructs a new informer for ClusterTestType type.
 // Always prefer using an informer factory to get a shared informer instead of getting an independent
 // one. This reduces memory footprint and number of connections to the server.
-func NewFilteredClusterTestTypeClusterInformer(client clientset.ClusterInterface, resyncPeriod time.Duration, indexers cache.Indexers, tweakListOptions internalinterfaces.TweakListOptionsFunc) cache.SharedIndexInformer {
+func NewFilteredClusterTestTypeClusterInformer(client clientset.ClusterInterface, resyncPeriod time.Duration, indexers cache.Indexers, tweakListOptions internalinterfaces.TweakListOptionsFunc) kcpcache.ScopeableSharedIndexInformer {
 	return kcpinformers.NewSharedIndexInformer(
 		&cache.ListWatch{
 			ListFunc: func(options metav1.ListOptions) (runtime.Object, error) {
@@ -83,7 +83,7 @@ func NewFilteredClusterTestTypeClusterInformer(client clientset.ClusterInterface
 	)
 }
 
-func (f *clusterTestTypeClusterInformer) defaultInformer(client clientset.ClusterInterface, resyncPeriod time.Duration) cache.SharedIndexInformer {
+func (f *clusterTestTypeClusterInformer) defaultInformer(client clientset.ClusterInterface, resyncPeriod time.Duration) kcpcache.ScopeableSharedIndexInformer {
 	return NewFilteredClusterTestTypeClusterInformer(client, resyncPeriod, cache.Indexers{
 		kcpcache.ClusterIndexName: kcpcache.ClusterIndexFunc,
 	},
@@ -91,7 +91,7 @@ func (f *clusterTestTypeClusterInformer) defaultInformer(client clientset.Cluste
 	)
 }
 
-func (f *clusterTestTypeClusterInformer) Informer() cache.SharedIndexInformer {
+func (f *clusterTestTypeClusterInformer) Informer() kcpcache.ScopeableSharedIndexInformer {
 	return f.factory.InformerFor(&secondexamplev1.ClusterTestType{}, f.defaultInformer)
 }
 

--- a/examples/pkg/kcpexisting/clients/informers/secondexample/v1/testtype.go
+++ b/examples/pkg/kcpexisting/clients/informers/secondexample/v1/testtype.go
@@ -42,7 +42,7 @@ import (
 // TestTypeClusterInformer provides access to a shared informer and lister for
 // TestTypes.
 type TestTypeClusterInformer interface {
-	Informer() cache.SharedIndexInformer
+	Informer() kcpcache.ScopeableSharedIndexInformer
 	Lister() secondexamplev1listers.TestTypeClusterLister
 }
 
@@ -54,14 +54,14 @@ type testTypeClusterInformer struct {
 // NewTestTypeClusterInformer constructs a new informer for TestType type.
 // Always prefer using an informer factory to get a shared informer instead of getting an independent
 // one. This reduces memory footprint and number of connections to the server.
-func NewTestTypeClusterInformer(client clientset.ClusterInterface, resyncPeriod time.Duration, indexers cache.Indexers) cache.SharedIndexInformer {
+func NewTestTypeClusterInformer(client clientset.ClusterInterface, resyncPeriod time.Duration, indexers cache.Indexers) kcpcache.ScopeableSharedIndexInformer {
 	return NewFilteredTestTypeClusterInformer(client, resyncPeriod, indexers, nil)
 }
 
 // NewFilteredTestTypeClusterInformer constructs a new informer for TestType type.
 // Always prefer using an informer factory to get a shared informer instead of getting an independent
 // one. This reduces memory footprint and number of connections to the server.
-func NewFilteredTestTypeClusterInformer(client clientset.ClusterInterface, resyncPeriod time.Duration, indexers cache.Indexers, tweakListOptions internalinterfaces.TweakListOptionsFunc) cache.SharedIndexInformer {
+func NewFilteredTestTypeClusterInformer(client clientset.ClusterInterface, resyncPeriod time.Duration, indexers cache.Indexers, tweakListOptions internalinterfaces.TweakListOptionsFunc) kcpcache.ScopeableSharedIndexInformer {
 	return kcpinformers.NewSharedIndexInformer(
 		&cache.ListWatch{
 			ListFunc: func(options metav1.ListOptions) (runtime.Object, error) {
@@ -83,7 +83,7 @@ func NewFilteredTestTypeClusterInformer(client clientset.ClusterInterface, resyn
 	)
 }
 
-func (f *testTypeClusterInformer) defaultInformer(client clientset.ClusterInterface, resyncPeriod time.Duration) cache.SharedIndexInformer {
+func (f *testTypeClusterInformer) defaultInformer(client clientset.ClusterInterface, resyncPeriod time.Duration) kcpcache.ScopeableSharedIndexInformer {
 	return NewFilteredTestTypeClusterInformer(client, resyncPeriod, cache.Indexers{
 		kcpcache.ClusterIndexName:             kcpcache.ClusterIndexFunc,
 		kcpcache.ClusterAndNamespaceIndexName: kcpcache.ClusterAndNamespaceIndexFunc},
@@ -91,7 +91,7 @@ func (f *testTypeClusterInformer) defaultInformer(client clientset.ClusterInterf
 	)
 }
 
-func (f *testTypeClusterInformer) Informer() cache.SharedIndexInformer {
+func (f *testTypeClusterInformer) Informer() kcpcache.ScopeableSharedIndexInformer {
 	return f.factory.InformerFor(&secondexamplev1.TestType{}, f.defaultInformer)
 }
 

--- a/pkg/internal/clientgen/fake_clientset.go
+++ b/pkg/internal/clientgen/fake_clientset.go
@@ -54,8 +54,6 @@ var fakeClientset = `
 package fake
 
 import (
-	"fmt"
-
 	kcptesting "github.com/kcp-dev/client-go/third_party/k8s.io/client-go/testing"
 	kcpfakediscovery "github.com/kcp-dev/client-go/third_party/k8s.io/client-go/discovery/fake"
 	"github.com/kcp-dev/logicalcluster/v2"
@@ -81,15 +79,7 @@ import (
 // for a real clientset and is mostly useful in simple unit tests.
 func NewSimpleClientset(objects ...runtime.Object) *ClusterClientset {
 	o := kcptesting.NewObjectTracker(clientscheme.Scheme, clientscheme.Codecs.UniversalDecoder())
-	for _, obj := range objects {
-		metaObj, ok := obj.(logicalcluster.Object)
-		if !ok {
-			panic(fmt.Sprintf("cannot extract logical cluster from %T", obj))
-		}
-		if err := o.Cluster(logicalcluster.From(metaObj)).Add(obj); err != nil {
-			panic(err)
-		}
-	}
+	o.AddAll(objects...)
 
 	cs := &ClusterClientset{Fake: &kcptesting.Fake{}, tracker: o}
 	cs.discovery = &kcpfakediscovery.FakeDiscovery{Fake: cs.Fake, Cluster: logicalcluster.Wildcard}

--- a/pkg/internal/clientgen/fake_type.go
+++ b/pkg/internal/clientgen/fake_type.go
@@ -103,8 +103,14 @@ func (c *FakeTypedClient) WriteContent(w io.Writer) error {
 	}
 	allVerbs := c.Kind.SupportedVerbs.Union(extensionVerbs)
 
+	groupName := c.Group.Group.String()
+	if groupName == "core" {
+		groupName = ""
+	}
+
 	m := map[string]interface{}{
 		"group":                          c.Group,
+		"groupName":                      groupName,
 		"kind":                           &c.Kind,
 		"extraImports":                   extraImports,
 		"importAliases":                  importAliases,
@@ -167,8 +173,8 @@ import (
 	{{.group.PackageAlias}}client "{{.singleClusterClientPackagePath}}/typed/{{.group.Group.PackageName}}/{{.group.Version.PackageName}}"
 )
 
-var {{.kind.Plural | lowerFirst}}Resource = schema.GroupVersionResource{Group: "{{.group.Group}}", Version: "{{.group.Version}}", Resource: "{{.kind.Plural | toLower}}"}
-var {{.kind.Plural | lowerFirst}}Kind = schema.GroupVersionKind{Group: "{{.group.Group}}", Version: "{{.group.Version}}", Kind: "{{.kind.String}}"}
+var {{.kind.Plural | lowerFirst}}Resource = schema.GroupVersionResource{Group: "{{.groupName}}", Version: "{{.group.Version.String | toLower}}", Resource: "{{.kind.Plural | toLower}}"}
+var {{.kind.Plural | lowerFirst}}Kind = schema.GroupVersionKind{Group: "{{.groupName}}", Version: "{{.group.Version.String | toLower}}", Kind: "{{.kind.String}}"}
 
 type {{.kind.Plural | lowerFirst}}ClusterClient struct {
 	*kcptesting.Fake

--- a/pkg/internal/informergen/factory.go
+++ b/pkg/internal/informergen/factory.go
@@ -65,6 +65,8 @@ import (
 	"sync"
 	"time"
 
+	kcpcache "github.com/kcp-dev/apimachinery/pkg/cache"
+
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/runtime/schema"
@@ -88,7 +90,7 @@ type sharedInformerFactory struct {
 	defaultResync time.Duration
 	customResync map[reflect.Type]time.Duration
 
-	informers map[reflect.Type]cache.SharedIndexInformer
+	informers map[reflect.Type]kcpcache.ScopeableSharedIndexInformer
 	// startedInformers is used for tracking which informers have been started.
 	// This allows Start() to be called multiple times safely.
 	startedInformers map[reflect.Type]bool
@@ -122,7 +124,7 @@ func NewSharedInformerFactoryWithOptions(client clientset.ClusterInterface, defa
 	factory := &sharedInformerFactory{
 		client:           client,
 		defaultResync:    defaultResync,
-		informers:        make(map[reflect.Type]cache.SharedIndexInformer),
+		informers:        make(map[reflect.Type]kcpcache.ScopeableSharedIndexInformer),
 		startedInformers: make(map[reflect.Type]bool),
 		customResync:     make(map[reflect.Type]time.Duration),
 	}
@@ -150,11 +152,11 @@ func (f *sharedInformerFactory) Start(stopCh <-chan struct{}) {
 
 // WaitForCacheSync waits for all started informers' cache were synced.
 func (f *sharedInformerFactory) WaitForCacheSync(stopCh <-chan struct{}) map[reflect.Type]bool {
-	informers := func()map[reflect.Type]cache.SharedIndexInformer{
+	informers := func()map[reflect.Type]kcpcache.ScopeableSharedIndexInformer{
                f.lock.Lock()
                defer f.lock.Unlock()
 
-               informers := map[reflect.Type]cache.SharedIndexInformer{}
+               informers := map[reflect.Type]kcpcache.ScopeableSharedIndexInformer{}
                for informerType, informer := range f.informers {
                        if f.startedInformers[informerType] {
                                informers[informerType] = informer
@@ -172,7 +174,7 @@ func (f *sharedInformerFactory) WaitForCacheSync(stopCh <-chan struct{}) map[ref
 
 // InternalInformerFor returns the SharedIndexInformer for obj using an internal
 // client.
-func (f *sharedInformerFactory) InformerFor(obj runtime.Object, newFunc internalinterfaces.NewInformerFunc) cache.SharedIndexInformer {
+func (f *sharedInformerFactory) InformerFor(obj runtime.Object, newFunc internalinterfaces.NewInformerFunc) kcpcache.ScopeableSharedIndexInformer {
   f.lock.Lock()
   defer f.lock.Unlock()
 

--- a/pkg/internal/informergen/factoryinterface.go
+++ b/pkg/internal/informergen/factoryinterface.go
@@ -50,20 +50,21 @@ package internalinterfaces
 import (
 	time "time"
 
+	kcpcache "github.com/kcp-dev/apimachinery/pkg/cache"
+
 	v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	runtime "k8s.io/apimachinery/pkg/runtime"
-	cache "k8s.io/client-go/tools/cache"
 
 	client "{{.clientsetPackagePath}}"
 )
 
-// NewInformerFunc takes client.ClusterInterface and time.Duration to return a SharedIndexInformer.
-type NewInformerFunc func(client.ClusterInterface, time.Duration) cache.SharedIndexInformer
+// NewInformerFunc takes client.ClusterInterface and time.Duration to return a ScopeableSharedIndexInformer.
+type NewInformerFunc func(client.ClusterInterface, time.Duration) kcpcache.ScopeableSharedIndexInformer
 
 // SharedInformerFactory a small interface to allow for adding an informer without an import cycle
 type SharedInformerFactory interface {
 	Start(stopCh <-chan struct{})
-	InformerFor(obj runtime.Object, newFunc NewInformerFunc) cache.SharedIndexInformer
+	InformerFor(obj runtime.Object, newFunc NewInformerFunc) kcpcache.ScopeableSharedIndexInformer
 }
 
 // TweakListOptionsFunc is a function that transforms a v1.ListOptions.

--- a/pkg/internal/informergen/generic.go
+++ b/pkg/internal/informergen/generic.go
@@ -63,7 +63,6 @@ import (
 	"fmt"
 
 	"k8s.io/apimachinery/pkg/runtime/schema"
-	"k8s.io/client-go/tools/cache"
 
 	kcpcache "github.com/kcp-dev/apimachinery/pkg/cache"
 
@@ -72,17 +71,17 @@ import (
 )
 
 type GenericClusterInformer interface {
-	Informer() cache.SharedIndexInformer
+	Informer() kcpcache.ScopeableSharedIndexInformer
 	Lister() kcpcache.GenericClusterLister
 }
 
 type genericClusterInformer struct {
-	informer cache.SharedIndexInformer
+	informer kcpcache.ScopeableSharedIndexInformer
 	resource schema.GroupResource
 }
 
 // Informer returns the SharedIndexInformer.
-func (f *genericClusterInformer) Informer() cache.SharedIndexInformer {
+func (f *genericClusterInformer) Informer() kcpcache.ScopeableSharedIndexInformer {
 	return f.informer
 }
 

--- a/pkg/internal/informergen/informer.go
+++ b/pkg/internal/informergen/informer.go
@@ -99,7 +99,7 @@ import (
 // {{.kind}}ClusterInformer provides access to a shared informer and lister for
 // {{.kind.Plural}}.
 type {{.kind}}ClusterInformer interface {
-	Informer() cache.SharedIndexInformer
+	Informer() kcpcache.ScopeableSharedIndexInformer
 	Lister() {{.group.PackageAlias}}listers.{{.kind}}ClusterLister
 }
 
@@ -111,14 +111,14 @@ type {{.kind.String | lowerFirst}}ClusterInformer struct {
 // New{{.kind}}ClusterInformer constructs a new informer for {{.kind.String}} type.
 // Always prefer using an informer factory to get a shared informer instead of getting an independent
 // one. This reduces memory footprint and number of connections to the server.
-func New{{.kind}}ClusterInformer(client clientset.ClusterInterface, resyncPeriod time.Duration, indexers cache.Indexers) cache.SharedIndexInformer {
+func New{{.kind}}ClusterInformer(client clientset.ClusterInterface, resyncPeriod time.Duration, indexers cache.Indexers) kcpcache.ScopeableSharedIndexInformer {
 	return NewFiltered{{.kind}}ClusterInformer(client, resyncPeriod, indexers, nil)
 }
 
 // NewFiltered{{.kind}}ClusterInformer constructs a new informer for {{.kind.String}} type.
 // Always prefer using an informer factory to get a shared informer instead of getting an independent
 // one. This reduces memory footprint and number of connections to the server.
-func NewFiltered{{.kind}}ClusterInformer(client clientset.ClusterInterface, resyncPeriod time.Duration, indexers cache.Indexers, tweakListOptions internalinterfaces.TweakListOptionsFunc) cache.SharedIndexInformer {
+func NewFiltered{{.kind}}ClusterInformer(client clientset.ClusterInterface, resyncPeriod time.Duration, indexers cache.Indexers, tweakListOptions internalinterfaces.TweakListOptionsFunc) kcpcache.ScopeableSharedIndexInformer {
 	return kcpinformers.NewSharedIndexInformer(
 		&cache.ListWatch{
 			ListFunc: func(options metav1.ListOptions) (runtime.Object, error) {
@@ -140,7 +140,7 @@ func NewFiltered{{.kind}}ClusterInformer(client clientset.ClusterInterface, resy
 	)
 }
 
-func (f *{{.kind.String|lowerFirst}}ClusterInformer) defaultInformer(client clientset.ClusterInterface, resyncPeriod time.Duration) cache.SharedIndexInformer {
+func (f *{{.kind.String|lowerFirst}}ClusterInformer) defaultInformer(client clientset.ClusterInterface, resyncPeriod time.Duration) kcpcache.ScopeableSharedIndexInformer {
 	return NewFiltered{{.kind}}ClusterInformer(client, resyncPeriod, cache.Indexers{
 			kcpcache.ClusterIndexName: kcpcache.ClusterIndexFunc,
 			{{if .kind.IsNamespaced}}kcpcache.ClusterAndNamespaceIndexName: kcpcache.ClusterAndNamespaceIndexFunc,{{end -}}
@@ -149,7 +149,7 @@ func (f *{{.kind.String|lowerFirst}}ClusterInformer) defaultInformer(client clie
 	)
 }
 
-func (f *{{.kind.String|lowerFirst}}ClusterInformer) Informer() cache.SharedIndexInformer {
+func (f *{{.kind.String|lowerFirst}}ClusterInformer) Informer() kcpcache.ScopeableSharedIndexInformer {
 	return f.factory.InformerFor(&{{.group.PackageAlias}}.{{.kind}}{}, f.defaultInformer)
 }
 


### PR DESCRIPTION
clientgen: correctly initialize fake

We need a pointer to this, as it contains a lock and shared state we
reference by passing the thing around. We need to initialize it,
therefore.

Signed-off-by: Steve Kuznetsov <skuznets@redhat.com>

---

clientgen: improve fake generators

Signed-off-by: Steve Kuznetsov <skuznets@redhat.com>

---

informergen: generate scope-able informers

Signed-off-by: Steve Kuznetsov <skuznets@redhat.com>

---

examples: update codegen

Signed-off-by: Steve Kuznetsov <skuznets@redhat.com>

---

