### PR TITLE
:sparkles: fix lister bug, improve scoping informer factory

### DIFF
--- a/examples/pkg/kcp/clients/informers/factory.go
+++ b/examples/pkg/kcp/clients/informers/factory.go
@@ -27,6 +27,7 @@ import (
 	"time"
 
 	kcpcache "github.com/kcp-dev/apimachinery/pkg/cache"
+	"github.com/kcp-dev/logicalcluster/v2"
 
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
@@ -156,10 +157,16 @@ func (f *sharedInformerFactory) InformerFor(obj runtime.Object, newFunc internal
 	return informer
 }
 
+type ScopedDynamicSharedInformerFactory interface {
+	ForResource(resource schema.GroupVersionResource) (GenericInformer, error)
+	Start(stopCh <-chan struct{})
+}
+
 // SharedInformerFactory provides shared informers for resources in all known
 // API group versions.
 type SharedInformerFactory interface {
 	internalinterfaces.SharedInformerFactory
+	Cluster(logicalcluster.Name) ScopedDynamicSharedInformerFactory
 	ForResource(resource schema.GroupVersionResource) (GenericClusterInformer, error)
 	WaitForCacheSync(stopCh <-chan struct{}) map[reflect.Type]bool
 
@@ -183,4 +190,28 @@ func (f *sharedInformerFactory) Existinginterfaces() existinginterfacesinformers
 
 func (f *sharedInformerFactory) Secondexample() secondexampleinformers.ClusterInterface {
 	return secondexampleinformers.New(f, f.tweakListOptions)
+}
+
+func (f *sharedInformerFactory) Cluster(cluster logicalcluster.Name) ScopedDynamicSharedInformerFactory {
+	return &scopedDynamicSharedInformerFactory{
+		sharedInformerFactory: f,
+		cluster:               cluster,
+	}
+}
+
+type scopedDynamicSharedInformerFactory struct {
+	*sharedInformerFactory
+	cluster logicalcluster.Name
+}
+
+func (f *scopedDynamicSharedInformerFactory) ForResource(resource schema.GroupVersionResource) (GenericInformer, error) {
+	clusterInformer, err := f.sharedInformerFactory.ForResource(resource)
+	if err != nil {
+		return nil, err
+	}
+	return clusterInformer.Cluster(f.cluster), nil
+}
+
+func (f *scopedDynamicSharedInformerFactory) Start(stopCh <-chan struct{}) {
+	f.sharedInformerFactory.Start(stopCh)
 }

--- a/examples/pkg/kcp/clients/listers/example/v1/testtype.go
+++ b/examples/pkg/kcp/clients/listers/example/v1/testtype.go
@@ -26,6 +26,7 @@ import (
 	"github.com/kcp-dev/logicalcluster/v2"
 
 	"k8s.io/apimachinery/pkg/api/errors"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/labels"
 	"k8s.io/client-go/tools/cache"
 
@@ -116,7 +117,12 @@ type testTypeNamespaceLister struct {
 func (s *testTypeNamespaceLister) List(selector labels.Selector) (ret []*examplev1.TestType, err error) {
 	selectAll := selector == nil || selector.Empty()
 
-	list, err := s.indexer.ByIndex(kcpcache.ClusterAndNamespaceIndexName, kcpcache.ClusterAndNamespaceIndexKey(s.cluster, s.namespace))
+	var list []interface{}
+	if s.namespace == metav1.NamespaceAll {
+		list, err = s.indexer.ByIndex(kcpcache.ClusterIndexName, kcpcache.ClusterIndexKey(s.cluster))
+	} else {
+		list, err = s.indexer.ByIndex(kcpcache.ClusterAndNamespaceIndexName, kcpcache.ClusterAndNamespaceIndexKey(s.cluster, s.namespace))
+	}
 	if err != nil {
 		return nil, err
 	}

--- a/examples/pkg/kcp/clients/listers/example/v1alpha1/testtype.go
+++ b/examples/pkg/kcp/clients/listers/example/v1alpha1/testtype.go
@@ -26,6 +26,7 @@ import (
 	"github.com/kcp-dev/logicalcluster/v2"
 
 	"k8s.io/apimachinery/pkg/api/errors"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/labels"
 	"k8s.io/client-go/tools/cache"
 
@@ -116,7 +117,12 @@ type testTypeNamespaceLister struct {
 func (s *testTypeNamespaceLister) List(selector labels.Selector) (ret []*examplev1alpha1.TestType, err error) {
 	selectAll := selector == nil || selector.Empty()
 
-	list, err := s.indexer.ByIndex(kcpcache.ClusterAndNamespaceIndexName, kcpcache.ClusterAndNamespaceIndexKey(s.cluster, s.namespace))
+	var list []interface{}
+	if s.namespace == metav1.NamespaceAll {
+		list, err = s.indexer.ByIndex(kcpcache.ClusterIndexName, kcpcache.ClusterIndexKey(s.cluster))
+	} else {
+		list, err = s.indexer.ByIndex(kcpcache.ClusterAndNamespaceIndexName, kcpcache.ClusterAndNamespaceIndexKey(s.cluster, s.namespace))
+	}
 	if err != nil {
 		return nil, err
 	}

--- a/examples/pkg/kcp/clients/listers/example/v2/testtype.go
+++ b/examples/pkg/kcp/clients/listers/example/v2/testtype.go
@@ -26,6 +26,7 @@ import (
 	"github.com/kcp-dev/logicalcluster/v2"
 
 	"k8s.io/apimachinery/pkg/api/errors"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/labels"
 	"k8s.io/client-go/tools/cache"
 
@@ -116,7 +117,12 @@ type testTypeNamespaceLister struct {
 func (s *testTypeNamespaceLister) List(selector labels.Selector) (ret []*examplev2.TestType, err error) {
 	selectAll := selector == nil || selector.Empty()
 
-	list, err := s.indexer.ByIndex(kcpcache.ClusterAndNamespaceIndexName, kcpcache.ClusterAndNamespaceIndexKey(s.cluster, s.namespace))
+	var list []interface{}
+	if s.namespace == metav1.NamespaceAll {
+		list, err = s.indexer.ByIndex(kcpcache.ClusterIndexName, kcpcache.ClusterIndexKey(s.cluster))
+	} else {
+		list, err = s.indexer.ByIndex(kcpcache.ClusterAndNamespaceIndexName, kcpcache.ClusterAndNamespaceIndexKey(s.cluster, s.namespace))
+	}
 	if err != nil {
 		return nil, err
 	}

--- a/examples/pkg/kcp/clients/listers/example3/v1/testtype.go
+++ b/examples/pkg/kcp/clients/listers/example3/v1/testtype.go
@@ -26,6 +26,7 @@ import (
 	"github.com/kcp-dev/logicalcluster/v2"
 
 	"k8s.io/apimachinery/pkg/api/errors"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/labels"
 	"k8s.io/client-go/tools/cache"
 
@@ -116,7 +117,12 @@ type testTypeNamespaceLister struct {
 func (s *testTypeNamespaceLister) List(selector labels.Selector) (ret []*example3v1.TestType, err error) {
 	selectAll := selector == nil || selector.Empty()
 
-	list, err := s.indexer.ByIndex(kcpcache.ClusterAndNamespaceIndexName, kcpcache.ClusterAndNamespaceIndexKey(s.cluster, s.namespace))
+	var list []interface{}
+	if s.namespace == metav1.NamespaceAll {
+		list, err = s.indexer.ByIndex(kcpcache.ClusterIndexName, kcpcache.ClusterIndexKey(s.cluster))
+	} else {
+		list, err = s.indexer.ByIndex(kcpcache.ClusterAndNamespaceIndexName, kcpcache.ClusterAndNamespaceIndexKey(s.cluster, s.namespace))
+	}
 	if err != nil {
 		return nil, err
 	}

--- a/examples/pkg/kcp/clients/listers/existinginterfaces/v1/testtype.go
+++ b/examples/pkg/kcp/clients/listers/existinginterfaces/v1/testtype.go
@@ -26,6 +26,7 @@ import (
 	"github.com/kcp-dev/logicalcluster/v2"
 
 	"k8s.io/apimachinery/pkg/api/errors"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/labels"
 	"k8s.io/client-go/tools/cache"
 
@@ -116,7 +117,12 @@ type testTypeNamespaceLister struct {
 func (s *testTypeNamespaceLister) List(selector labels.Selector) (ret []*existinginterfacesv1.TestType, err error) {
 	selectAll := selector == nil || selector.Empty()
 
-	list, err := s.indexer.ByIndex(kcpcache.ClusterAndNamespaceIndexName, kcpcache.ClusterAndNamespaceIndexKey(s.cluster, s.namespace))
+	var list []interface{}
+	if s.namespace == metav1.NamespaceAll {
+		list, err = s.indexer.ByIndex(kcpcache.ClusterIndexName, kcpcache.ClusterIndexKey(s.cluster))
+	} else {
+		list, err = s.indexer.ByIndex(kcpcache.ClusterAndNamespaceIndexName, kcpcache.ClusterAndNamespaceIndexKey(s.cluster, s.namespace))
+	}
 	if err != nil {
 		return nil, err
 	}

--- a/examples/pkg/kcp/clients/listers/secondexample/v1/testtype.go
+++ b/examples/pkg/kcp/clients/listers/secondexample/v1/testtype.go
@@ -26,6 +26,7 @@ import (
 	"github.com/kcp-dev/logicalcluster/v2"
 
 	"k8s.io/apimachinery/pkg/api/errors"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/labels"
 	"k8s.io/client-go/tools/cache"
 
@@ -116,7 +117,12 @@ type testTypeNamespaceLister struct {
 func (s *testTypeNamespaceLister) List(selector labels.Selector) (ret []*secondexamplev1.TestType, err error) {
 	selectAll := selector == nil || selector.Empty()
 
-	list, err := s.indexer.ByIndex(kcpcache.ClusterAndNamespaceIndexName, kcpcache.ClusterAndNamespaceIndexKey(s.cluster, s.namespace))
+	var list []interface{}
+	if s.namespace == metav1.NamespaceAll {
+		list, err = s.indexer.ByIndex(kcpcache.ClusterIndexName, kcpcache.ClusterIndexKey(s.cluster))
+	} else {
+		list, err = s.indexer.ByIndex(kcpcache.ClusterAndNamespaceIndexName, kcpcache.ClusterAndNamespaceIndexKey(s.cluster, s.namespace))
+	}
 	if err != nil {
 		return nil, err
 	}

--- a/examples/pkg/kcpexisting/clients/informers/factory.go
+++ b/examples/pkg/kcpexisting/clients/informers/factory.go
@@ -27,12 +27,14 @@ import (
 	"time"
 
 	kcpcache "github.com/kcp-dev/apimachinery/pkg/cache"
+	"github.com/kcp-dev/logicalcluster/v2"
 
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/runtime/schema"
 	"k8s.io/client-go/tools/cache"
 
+	upstreaminformers "acme.corp/pkg/generated/informers/externalversions"
 	clientset "acme.corp/pkg/kcpexisting/clients/clientset/versioned"
 	exampleinformers "acme.corp/pkg/kcpexisting/clients/informers/example"
 	example3informers "acme.corp/pkg/kcpexisting/clients/informers/example3"
@@ -156,10 +158,16 @@ func (f *sharedInformerFactory) InformerFor(obj runtime.Object, newFunc internal
 	return informer
 }
 
+type ScopedDynamicSharedInformerFactory interface {
+	ForResource(resource schema.GroupVersionResource) (upstreaminformers.GenericInformer, error)
+	Start(stopCh <-chan struct{})
+}
+
 // SharedInformerFactory provides shared informers for resources in all known
 // API group versions.
 type SharedInformerFactory interface {
 	internalinterfaces.SharedInformerFactory
+	Cluster(logicalcluster.Name) ScopedDynamicSharedInformerFactory
 	ForResource(resource schema.GroupVersionResource) (GenericClusterInformer, error)
 	WaitForCacheSync(stopCh <-chan struct{}) map[reflect.Type]bool
 
@@ -183,4 +191,28 @@ func (f *sharedInformerFactory) Existinginterfaces() existinginterfacesinformers
 
 func (f *sharedInformerFactory) Secondexample() secondexampleinformers.ClusterInterface {
 	return secondexampleinformers.New(f, f.tweakListOptions)
+}
+
+func (f *sharedInformerFactory) Cluster(cluster logicalcluster.Name) ScopedDynamicSharedInformerFactory {
+	return &scopedDynamicSharedInformerFactory{
+		sharedInformerFactory: f,
+		cluster:               cluster,
+	}
+}
+
+type scopedDynamicSharedInformerFactory struct {
+	*sharedInformerFactory
+	cluster logicalcluster.Name
+}
+
+func (f *scopedDynamicSharedInformerFactory) ForResource(resource schema.GroupVersionResource) (upstreaminformers.GenericInformer, error) {
+	clusterInformer, err := f.sharedInformerFactory.ForResource(resource)
+	if err != nil {
+		return nil, err
+	}
+	return clusterInformer.Cluster(f.cluster), nil
+}
+
+func (f *scopedDynamicSharedInformerFactory) Start(stopCh <-chan struct{}) {
+	f.sharedInformerFactory.Start(stopCh)
 }

--- a/examples/pkg/kcpexisting/clients/informers/generic.go
+++ b/examples/pkg/kcpexisting/clients/informers/generic.go
@@ -37,17 +37,13 @@ import (
 	example3v1 "acme.corp/pkg/apis/example3/v1"
 	existinginterfacesv1 "acme.corp/pkg/apis/existinginterfaces/v1"
 	secondexamplev1 "acme.corp/pkg/apis/secondexample/v1"
+	upstreaminformers "acme.corp/pkg/generated/informers/externalversions"
 )
 
 type GenericClusterInformer interface {
-	Cluster(logicalcluster.Name) GenericInformer
+	Cluster(logicalcluster.Name) upstreaminformers.GenericInformer
 	Informer() kcpcache.ScopeableSharedIndexInformer
 	Lister() kcpcache.GenericClusterLister
-}
-
-type GenericInformer interface {
-	Informer() cache.SharedIndexInformer
-	Lister() cache.GenericLister
 }
 
 type genericClusterInformer struct {
@@ -66,7 +62,7 @@ func (f *genericClusterInformer) Lister() kcpcache.GenericClusterLister {
 }
 
 // Cluster scopes to a GenericInformer.
-func (f *genericClusterInformer) Cluster(cluster logicalcluster.Name) GenericInformer {
+func (f *genericClusterInformer) Cluster(cluster logicalcluster.Name) upstreaminformers.GenericInformer {
 	return &genericInformer{
 		informer: f.Informer().Cluster(cluster),
 		lister:   f.Lister().ByCluster(cluster),

--- a/examples/pkg/kcpexisting/clients/listers/example/v1/testtype.go
+++ b/examples/pkg/kcpexisting/clients/listers/example/v1/testtype.go
@@ -26,6 +26,7 @@ import (
 	"github.com/kcp-dev/logicalcluster/v2"
 
 	"k8s.io/apimachinery/pkg/api/errors"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/labels"
 	"k8s.io/client-go/tools/cache"
 
@@ -106,7 +107,12 @@ type testTypeNamespaceLister struct {
 func (s *testTypeNamespaceLister) List(selector labels.Selector) (ret []*examplev1.TestType, err error) {
 	selectAll := selector == nil || selector.Empty()
 
-	list, err := s.indexer.ByIndex(kcpcache.ClusterAndNamespaceIndexName, kcpcache.ClusterAndNamespaceIndexKey(s.cluster, s.namespace))
+	var list []interface{}
+	if s.namespace == metav1.NamespaceAll {
+		list, err = s.indexer.ByIndex(kcpcache.ClusterIndexName, kcpcache.ClusterIndexKey(s.cluster))
+	} else {
+		list, err = s.indexer.ByIndex(kcpcache.ClusterAndNamespaceIndexName, kcpcache.ClusterAndNamespaceIndexKey(s.cluster, s.namespace))
+	}
 	if err != nil {
 		return nil, err
 	}

--- a/examples/pkg/kcpexisting/clients/listers/example/v1alpha1/testtype.go
+++ b/examples/pkg/kcpexisting/clients/listers/example/v1alpha1/testtype.go
@@ -26,6 +26,7 @@ import (
 	"github.com/kcp-dev/logicalcluster/v2"
 
 	"k8s.io/apimachinery/pkg/api/errors"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/labels"
 	"k8s.io/client-go/tools/cache"
 
@@ -106,7 +107,12 @@ type testTypeNamespaceLister struct {
 func (s *testTypeNamespaceLister) List(selector labels.Selector) (ret []*examplev1alpha1.TestType, err error) {
 	selectAll := selector == nil || selector.Empty()
 
-	list, err := s.indexer.ByIndex(kcpcache.ClusterAndNamespaceIndexName, kcpcache.ClusterAndNamespaceIndexKey(s.cluster, s.namespace))
+	var list []interface{}
+	if s.namespace == metav1.NamespaceAll {
+		list, err = s.indexer.ByIndex(kcpcache.ClusterIndexName, kcpcache.ClusterIndexKey(s.cluster))
+	} else {
+		list, err = s.indexer.ByIndex(kcpcache.ClusterAndNamespaceIndexName, kcpcache.ClusterAndNamespaceIndexKey(s.cluster, s.namespace))
+	}
 	if err != nil {
 		return nil, err
 	}

--- a/examples/pkg/kcpexisting/clients/listers/example/v2/testtype.go
+++ b/examples/pkg/kcpexisting/clients/listers/example/v2/testtype.go
@@ -26,6 +26,7 @@ import (
 	"github.com/kcp-dev/logicalcluster/v2"
 
 	"k8s.io/apimachinery/pkg/api/errors"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/labels"
 	"k8s.io/client-go/tools/cache"
 
@@ -106,7 +107,12 @@ type testTypeNamespaceLister struct {
 func (s *testTypeNamespaceLister) List(selector labels.Selector) (ret []*examplev2.TestType, err error) {
 	selectAll := selector == nil || selector.Empty()
 
-	list, err := s.indexer.ByIndex(kcpcache.ClusterAndNamespaceIndexName, kcpcache.ClusterAndNamespaceIndexKey(s.cluster, s.namespace))
+	var list []interface{}
+	if s.namespace == metav1.NamespaceAll {
+		list, err = s.indexer.ByIndex(kcpcache.ClusterIndexName, kcpcache.ClusterIndexKey(s.cluster))
+	} else {
+		list, err = s.indexer.ByIndex(kcpcache.ClusterAndNamespaceIndexName, kcpcache.ClusterAndNamespaceIndexKey(s.cluster, s.namespace))
+	}
 	if err != nil {
 		return nil, err
 	}

--- a/examples/pkg/kcpexisting/clients/listers/example3/v1/testtype.go
+++ b/examples/pkg/kcpexisting/clients/listers/example3/v1/testtype.go
@@ -26,6 +26,7 @@ import (
 	"github.com/kcp-dev/logicalcluster/v2"
 
 	"k8s.io/apimachinery/pkg/api/errors"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/labels"
 	"k8s.io/client-go/tools/cache"
 
@@ -106,7 +107,12 @@ type testTypeNamespaceLister struct {
 func (s *testTypeNamespaceLister) List(selector labels.Selector) (ret []*example3v1.TestType, err error) {
 	selectAll := selector == nil || selector.Empty()
 
-	list, err := s.indexer.ByIndex(kcpcache.ClusterAndNamespaceIndexName, kcpcache.ClusterAndNamespaceIndexKey(s.cluster, s.namespace))
+	var list []interface{}
+	if s.namespace == metav1.NamespaceAll {
+		list, err = s.indexer.ByIndex(kcpcache.ClusterIndexName, kcpcache.ClusterIndexKey(s.cluster))
+	} else {
+		list, err = s.indexer.ByIndex(kcpcache.ClusterAndNamespaceIndexName, kcpcache.ClusterAndNamespaceIndexKey(s.cluster, s.namespace))
+	}
 	if err != nil {
 		return nil, err
 	}

--- a/examples/pkg/kcpexisting/clients/listers/existinginterfaces/v1/testtype.go
+++ b/examples/pkg/kcpexisting/clients/listers/existinginterfaces/v1/testtype.go
@@ -26,6 +26,7 @@ import (
 	"github.com/kcp-dev/logicalcluster/v2"
 
 	"k8s.io/apimachinery/pkg/api/errors"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/labels"
 	"k8s.io/client-go/tools/cache"
 
@@ -106,7 +107,12 @@ type testTypeNamespaceLister struct {
 func (s *testTypeNamespaceLister) List(selector labels.Selector) (ret []*existinginterfacesv1.TestType, err error) {
 	selectAll := selector == nil || selector.Empty()
 
-	list, err := s.indexer.ByIndex(kcpcache.ClusterAndNamespaceIndexName, kcpcache.ClusterAndNamespaceIndexKey(s.cluster, s.namespace))
+	var list []interface{}
+	if s.namespace == metav1.NamespaceAll {
+		list, err = s.indexer.ByIndex(kcpcache.ClusterIndexName, kcpcache.ClusterIndexKey(s.cluster))
+	} else {
+		list, err = s.indexer.ByIndex(kcpcache.ClusterAndNamespaceIndexName, kcpcache.ClusterAndNamespaceIndexKey(s.cluster, s.namespace))
+	}
 	if err != nil {
 		return nil, err
 	}

--- a/examples/pkg/kcpexisting/clients/listers/secondexample/v1/testtype.go
+++ b/examples/pkg/kcpexisting/clients/listers/secondexample/v1/testtype.go
@@ -26,6 +26,7 @@ import (
 	"github.com/kcp-dev/logicalcluster/v2"
 
 	"k8s.io/apimachinery/pkg/api/errors"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/labels"
 	"k8s.io/client-go/tools/cache"
 
@@ -106,7 +107,12 @@ type testTypeNamespaceLister struct {
 func (s *testTypeNamespaceLister) List(selector labels.Selector) (ret []*secondexamplev1.TestType, err error) {
 	selectAll := selector == nil || selector.Empty()
 
-	list, err := s.indexer.ByIndex(kcpcache.ClusterAndNamespaceIndexName, kcpcache.ClusterAndNamespaceIndexKey(s.cluster, s.namespace))
+	var list []interface{}
+	if s.namespace == metav1.NamespaceAll {
+		list, err = s.indexer.ByIndex(kcpcache.ClusterIndexName, kcpcache.ClusterIndexKey(s.cluster))
+	} else {
+		list, err = s.indexer.ByIndex(kcpcache.ClusterAndNamespaceIndexName, kcpcache.ClusterAndNamespaceIndexKey(s.cluster, s.namespace))
+	}
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/generators/informergen/informergen.go
+++ b/pkg/generators/informergen/informergen.go
@@ -109,9 +109,10 @@ func (g Generator) Generate(ctx *genall.GenerationContext) error {
 	factoryPath := filepath.Join(informersDir, "factory.go")
 	logger.WithValues("path", factoryPath).Info("generating informer factory")
 	if err := util.WriteGeneratedCode(ctx, headerText, &informergen.Factory{
-		Groups:               onlyGroups,
-		PackagePath:          filepath.Join(g.OutputPackagePath, informersDir),
-		ClientsetPackagePath: filepath.Join(g.OutputPackagePath, clientsetDir),
+		Groups:                           onlyGroups,
+		PackagePath:                      filepath.Join(g.OutputPackagePath, informersDir),
+		ClientsetPackagePath:             filepath.Join(g.OutputPackagePath, clientsetDir),
+		SingleClusterInformerPackagePath: g.SingleClusterInformerPackagePath,
 	}, factoryPath); err != nil {
 		return err
 	}
@@ -129,9 +130,10 @@ func (g Generator) Generate(ctx *genall.GenerationContext) error {
 	genericPath := filepath.Join(informersDir, "generic.go")
 	logger.WithValues("path", factoryPath).Info("generating generic informers")
 	if err := util.WriteGeneratedCode(ctx, headerText, &informergen.Generic{
-		Groups:            groupInfo,
-		GroupVersionKinds: gvks,
-		APIPackagePath:    g.APIPackagePath,
+		Groups:                           groupInfo,
+		GroupVersionKinds:                gvks,
+		APIPackagePath:                   g.APIPackagePath,
+		SingleClusterInformerPackagePath: g.SingleClusterInformerPackagePath,
 	}, genericPath); err != nil {
 		return err
 	}


### PR DESCRIPTION
listergen: use correct index on cross-namespace list

Signed-off-by: Steve Kuznetsov <skuznets@redhat.com>

---

informergen: allow scoping a factory for generic informers

Signed-off-by: Steve Kuznetsov <skuznets@redhat.com>

---

examples: update generated code

Signed-off-by: Steve Kuznetsov <skuznets@redhat.com>

---