### PR TITLE
:sparkles: improve listers and informers

### DIFF
--- a/examples/go.mod
+++ b/examples/go.mod
@@ -5,7 +5,7 @@ go 1.18
 replace acme.corp/pkg => ./pkg
 
 require (
-	github.com/kcp-dev/apimachinery v0.0.0-20221019133255-9e1e13940519
+	github.com/kcp-dev/apimachinery v0.0.0-20221102195355-d65878bc16be
 	github.com/kcp-dev/client-go v0.0.0-20221013125607-cac9fbfe7455
 	github.com/kcp-dev/logicalcluster/v2 v2.0.0-alpha.3
 	k8s.io/apimachinery v0.25.2

--- a/examples/go.sum
+++ b/examples/go.sum
@@ -139,8 +139,8 @@ github.com/json-iterator/go v1.1.12 h1:PV8peI4a0ysnczrg+LtxykD8LfKY9ML6u2jnxaEnr
 github.com/json-iterator/go v1.1.12/go.mod h1:e30LSqwooZae/UwlEbR2852Gd8hjQvJoHmT4TnhNGBo=
 github.com/jstemmer/go-junit-report v0.0.0-20190106144839-af01ea7f8024/go.mod h1:6v2b51hI/fHJwM22ozAgKL4VKDeJcHhJFhtBdhmNjmU=
 github.com/jstemmer/go-junit-report v0.9.1/go.mod h1:Brl9GWCQeLvo8nXZwPNNblvFj/XSXhF0NWZEnDohbsk=
-github.com/kcp-dev/apimachinery v0.0.0-20221019133255-9e1e13940519 h1:eU1HvmmP8TbzS2pB9IX2Spky20n6V79/KgX4ssiG/A8=
-github.com/kcp-dev/apimachinery v0.0.0-20221019133255-9e1e13940519/go.mod h1:qnvUHkdxOrNzX17yX+z8r81CZEBuFdveNzWqFlwZ55w=
+github.com/kcp-dev/apimachinery v0.0.0-20221102195355-d65878bc16be h1:2uDzJ896+ojtzgr9HJL8+tZEoqhq8blwymGinWFrQ6E=
+github.com/kcp-dev/apimachinery v0.0.0-20221102195355-d65878bc16be/go.mod h1:qnvUHkdxOrNzX17yX+z8r81CZEBuFdveNzWqFlwZ55w=
 github.com/kcp-dev/client-go v0.0.0-20221013125607-cac9fbfe7455 h1:4tYJ1Pkjwsv9x+TKRyFizyUTJL4SfbNahPckRyIMD4A=
 github.com/kcp-dev/client-go v0.0.0-20221013125607-cac9fbfe7455/go.mod h1:E/pWNs9gXdW4QbDJhDl6yVWv22AHU+EhSv54EagP96I=
 github.com/kcp-dev/logicalcluster/v2 v2.0.0-alpha.3 h1:+DwIG/loh2nDB9c/FqNvLzFFq/YtBliLxAfw/uWNzyE=

--- a/examples/pkg/kcp/clients/informers/externalversions/factory.go
+++ b/examples/pkg/kcp/clients/informers/externalversions/factory.go
@@ -43,7 +43,12 @@ import (
 )
 
 // SharedInformerOption defines the functional option type for SharedInformerFactory.
-type SharedInformerOption func(*sharedInformerFactory) *sharedInformerFactory
+type SharedInformerOption func(*SharedInformerOptions) *SharedInformerOptions
+
+type SharedInformerOptions struct {
+	customResync     map[reflect.Type]time.Duration
+	tweakListOptions internalinterfaces.TweakListOptionsFunc
+}
 
 type sharedInformerFactory struct {
 	client           clientset.ClusterInterface
@@ -60,19 +65,19 @@ type sharedInformerFactory struct {
 
 // WithCustomResyncConfig sets a custom resync period for the specified informer types.
 func WithCustomResyncConfig(resyncConfig map[metav1.Object]time.Duration) SharedInformerOption {
-	return func(factory *sharedInformerFactory) *sharedInformerFactory {
+	return func(opts *SharedInformerOptions) *SharedInformerOptions {
 		for k, v := range resyncConfig {
-			factory.customResync[reflect.TypeOf(k)] = v
+			opts.customResync[reflect.TypeOf(k)] = v
 		}
-		return factory
+		return opts
 	}
 }
 
 // WithTweakListOptions sets a custom filter on all listers of the configured SharedInformerFactory.
 func WithTweakListOptions(tweakListOptions internalinterfaces.TweakListOptionsFunc) SharedInformerOption {
-	return func(factory *sharedInformerFactory) *sharedInformerFactory {
-		factory.tweakListOptions = tweakListOptions
-		return factory
+	return func(opts *SharedInformerOptions) *SharedInformerOptions {
+		opts.tweakListOptions = tweakListOptions
+		return opts
 	}
 }
 
@@ -91,10 +96,18 @@ func NewSharedInformerFactoryWithOptions(client clientset.ClusterInterface, defa
 		customResync:     make(map[reflect.Type]time.Duration),
 	}
 
+	opts := &SharedInformerOptions{
+		customResync: make(map[reflect.Type]time.Duration),
+	}
+
 	// Apply all options
 	for _, opt := range options {
-		factory = opt(factory)
+		opts = opt(opts)
 	}
+
+	// Forward options to the factory
+	factory.customResync = opts.customResync
+	factory.tweakListOptions = opts.tweakListOptions
 
 	return factory
 }
@@ -134,7 +147,7 @@ func (f *sharedInformerFactory) WaitForCacheSync(stopCh <-chan struct{}) map[ref
 	return res
 }
 
-// InternalInformerFor returns the SharedIndexInformer for obj using an internal
+// InformerFor returns the SharedIndexInformer for obj using an internal
 // client.
 func (f *sharedInformerFactory) InformerFor(obj runtime.Object, newFunc internalinterfaces.NewInformerFunc) kcpcache.ScopeableSharedIndexInformer {
 	f.lock.Lock()

--- a/examples/pkg/kcp/clients/informers/externalversions/internalinterfaces/factory_interfaces.go
+++ b/examples/pkg/kcp/clients/informers/externalversions/internalinterfaces/factory_interfaces.go
@@ -26,14 +26,14 @@ import (
 
 	kcpcache "github.com/kcp-dev/apimachinery/pkg/cache"
 
-	v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	runtime "k8s.io/apimachinery/pkg/runtime"
 
-	client "acme.corp/pkg/kcp/clients/clientset/versioned"
+	clientset "acme.corp/pkg/kcp/clients/clientset/versioned"
 )
 
-// NewInformerFunc takes client.ClusterInterface and time.Duration to return a ScopeableSharedIndexInformer.
-type NewInformerFunc func(client.ClusterInterface, time.Duration) kcpcache.ScopeableSharedIndexInformer
+// NewInformerFunc takes clientset.ClusterInterface and time.Duration to return a ScopeableSharedIndexInformer.
+type NewInformerFunc func(clientset.ClusterInterface, time.Duration) kcpcache.ScopeableSharedIndexInformer
 
 // SharedInformerFactory a small interface to allow for adding an informer without an import cycle
 type SharedInformerFactory interface {
@@ -41,5 +41,5 @@ type SharedInformerFactory interface {
 	InformerFor(obj runtime.Object, newFunc NewInformerFunc) kcpcache.ScopeableSharedIndexInformer
 }
 
-// TweakListOptionsFunc is a function that transforms a v1.ListOptions.
-type TweakListOptionsFunc func(*v1.ListOptions)
+// TweakListOptionsFunc is a function that transforms a metav1.ListOptions.
+type TweakListOptionsFunc func(*metav1.ListOptions)

--- a/examples/pkg/kcp/clients/listers/example/v1/clustertesttype.go
+++ b/examples/pkg/kcp/clients/listers/example/v1/clustertesttype.go
@@ -73,24 +73,9 @@ type clusterTestTypeLister struct {
 
 // List lists all ClusterTestTypes in the indexer for a workspace.
 func (s *clusterTestTypeLister) List(selector labels.Selector) (ret []*examplev1.ClusterTestType, err error) {
-	selectAll := selector == nil || selector.Empty()
-
-	list, err := s.indexer.ByIndex(kcpcache.ClusterIndexName, kcpcache.ClusterIndexKey(s.cluster))
-	if err != nil {
-		return nil, err
-	}
-
-	for i := range list {
-		obj := list[i].(*examplev1.ClusterTestType)
-		if selectAll {
-			ret = append(ret, obj)
-		} else {
-			if selector.Matches(labels.Set(obj.GetLabels())) {
-				ret = append(ret, obj)
-			}
-		}
-	}
-
+	err = kcpcache.ListAllByCluster(s.indexer, s.cluster, selector, func(i interface{}) {
+		ret = append(ret, i.(*examplev1.ClusterTestType))
+	})
 	return ret, err
 }
 

--- a/examples/pkg/kcp/clients/listers/example/v1/testtype.go
+++ b/examples/pkg/kcp/clients/listers/example/v1/testtype.go
@@ -26,7 +26,6 @@ import (
 	"github.com/kcp-dev/logicalcluster/v2"
 
 	"k8s.io/apimachinery/pkg/api/errors"
-	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/labels"
 	"k8s.io/client-go/tools/cache"
 
@@ -74,24 +73,9 @@ type testTypeLister struct {
 
 // List lists all TestTypes in the indexer for a workspace.
 func (s *testTypeLister) List(selector labels.Selector) (ret []*examplev1.TestType, err error) {
-	selectAll := selector == nil || selector.Empty()
-
-	list, err := s.indexer.ByIndex(kcpcache.ClusterIndexName, kcpcache.ClusterIndexKey(s.cluster))
-	if err != nil {
-		return nil, err
-	}
-
-	for i := range list {
-		obj := list[i].(*examplev1.TestType)
-		if selectAll {
-			ret = append(ret, obj)
-		} else {
-			if selector.Matches(labels.Set(obj.GetLabels())) {
-				ret = append(ret, obj)
-			}
-		}
-	}
-
+	err = kcpcache.ListAllByCluster(s.indexer, s.cluster, selector, func(i interface{}) {
+		ret = append(ret, i.(*examplev1.TestType))
+	})
 	return ret, err
 }
 
@@ -115,28 +99,9 @@ type testTypeNamespaceLister struct {
 
 // List lists all TestTypes in the indexer for a given workspace and namespace.
 func (s *testTypeNamespaceLister) List(selector labels.Selector) (ret []*examplev1.TestType, err error) {
-	selectAll := selector == nil || selector.Empty()
-
-	var list []interface{}
-	if s.namespace == metav1.NamespaceAll {
-		list, err = s.indexer.ByIndex(kcpcache.ClusterIndexName, kcpcache.ClusterIndexKey(s.cluster))
-	} else {
-		list, err = s.indexer.ByIndex(kcpcache.ClusterAndNamespaceIndexName, kcpcache.ClusterAndNamespaceIndexKey(s.cluster, s.namespace))
-	}
-	if err != nil {
-		return nil, err
-	}
-
-	for i := range list {
-		obj := list[i].(*examplev1.TestType)
-		if selectAll {
-			ret = append(ret, obj)
-		} else {
-			if selector.Matches(labels.Set(obj.GetLabels())) {
-				ret = append(ret, obj)
-			}
-		}
-	}
+	err = kcpcache.ListAllByClusterAndNamespace(s.indexer, s.cluster, s.namespace, selector, func(i interface{}) {
+		ret = append(ret, i.(*examplev1.TestType))
+	})
 	return ret, err
 }
 

--- a/examples/pkg/kcp/clients/listers/example/v1alpha1/clustertesttype.go
+++ b/examples/pkg/kcp/clients/listers/example/v1alpha1/clustertesttype.go
@@ -73,24 +73,9 @@ type clusterTestTypeLister struct {
 
 // List lists all ClusterTestTypes in the indexer for a workspace.
 func (s *clusterTestTypeLister) List(selector labels.Selector) (ret []*examplev1alpha1.ClusterTestType, err error) {
-	selectAll := selector == nil || selector.Empty()
-
-	list, err := s.indexer.ByIndex(kcpcache.ClusterIndexName, kcpcache.ClusterIndexKey(s.cluster))
-	if err != nil {
-		return nil, err
-	}
-
-	for i := range list {
-		obj := list[i].(*examplev1alpha1.ClusterTestType)
-		if selectAll {
-			ret = append(ret, obj)
-		} else {
-			if selector.Matches(labels.Set(obj.GetLabels())) {
-				ret = append(ret, obj)
-			}
-		}
-	}
-
+	err = kcpcache.ListAllByCluster(s.indexer, s.cluster, selector, func(i interface{}) {
+		ret = append(ret, i.(*examplev1alpha1.ClusterTestType))
+	})
 	return ret, err
 }
 

--- a/examples/pkg/kcp/clients/listers/example/v1alpha1/testtype.go
+++ b/examples/pkg/kcp/clients/listers/example/v1alpha1/testtype.go
@@ -26,7 +26,6 @@ import (
 	"github.com/kcp-dev/logicalcluster/v2"
 
 	"k8s.io/apimachinery/pkg/api/errors"
-	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/labels"
 	"k8s.io/client-go/tools/cache"
 
@@ -74,24 +73,9 @@ type testTypeLister struct {
 
 // List lists all TestTypes in the indexer for a workspace.
 func (s *testTypeLister) List(selector labels.Selector) (ret []*examplev1alpha1.TestType, err error) {
-	selectAll := selector == nil || selector.Empty()
-
-	list, err := s.indexer.ByIndex(kcpcache.ClusterIndexName, kcpcache.ClusterIndexKey(s.cluster))
-	if err != nil {
-		return nil, err
-	}
-
-	for i := range list {
-		obj := list[i].(*examplev1alpha1.TestType)
-		if selectAll {
-			ret = append(ret, obj)
-		} else {
-			if selector.Matches(labels.Set(obj.GetLabels())) {
-				ret = append(ret, obj)
-			}
-		}
-	}
-
+	err = kcpcache.ListAllByCluster(s.indexer, s.cluster, selector, func(i interface{}) {
+		ret = append(ret, i.(*examplev1alpha1.TestType))
+	})
 	return ret, err
 }
 
@@ -115,28 +99,9 @@ type testTypeNamespaceLister struct {
 
 // List lists all TestTypes in the indexer for a given workspace and namespace.
 func (s *testTypeNamespaceLister) List(selector labels.Selector) (ret []*examplev1alpha1.TestType, err error) {
-	selectAll := selector == nil || selector.Empty()
-
-	var list []interface{}
-	if s.namespace == metav1.NamespaceAll {
-		list, err = s.indexer.ByIndex(kcpcache.ClusterIndexName, kcpcache.ClusterIndexKey(s.cluster))
-	} else {
-		list, err = s.indexer.ByIndex(kcpcache.ClusterAndNamespaceIndexName, kcpcache.ClusterAndNamespaceIndexKey(s.cluster, s.namespace))
-	}
-	if err != nil {
-		return nil, err
-	}
-
-	for i := range list {
-		obj := list[i].(*examplev1alpha1.TestType)
-		if selectAll {
-			ret = append(ret, obj)
-		} else {
-			if selector.Matches(labels.Set(obj.GetLabels())) {
-				ret = append(ret, obj)
-			}
-		}
-	}
+	err = kcpcache.ListAllByClusterAndNamespace(s.indexer, s.cluster, s.namespace, selector, func(i interface{}) {
+		ret = append(ret, i.(*examplev1alpha1.TestType))
+	})
 	return ret, err
 }
 

--- a/examples/pkg/kcp/clients/listers/example/v1beta1/clustertesttype.go
+++ b/examples/pkg/kcp/clients/listers/example/v1beta1/clustertesttype.go
@@ -73,24 +73,9 @@ type clusterTestTypeLister struct {
 
 // List lists all ClusterTestTypes in the indexer for a workspace.
 func (s *clusterTestTypeLister) List(selector labels.Selector) (ret []*examplev1beta1.ClusterTestType, err error) {
-	selectAll := selector == nil || selector.Empty()
-
-	list, err := s.indexer.ByIndex(kcpcache.ClusterIndexName, kcpcache.ClusterIndexKey(s.cluster))
-	if err != nil {
-		return nil, err
-	}
-
-	for i := range list {
-		obj := list[i].(*examplev1beta1.ClusterTestType)
-		if selectAll {
-			ret = append(ret, obj)
-		} else {
-			if selector.Matches(labels.Set(obj.GetLabels())) {
-				ret = append(ret, obj)
-			}
-		}
-	}
-
+	err = kcpcache.ListAllByCluster(s.indexer, s.cluster, selector, func(i interface{}) {
+		ret = append(ret, i.(*examplev1beta1.ClusterTestType))
+	})
 	return ret, err
 }
 

--- a/examples/pkg/kcp/clients/listers/example/v2/clustertesttype.go
+++ b/examples/pkg/kcp/clients/listers/example/v2/clustertesttype.go
@@ -73,24 +73,9 @@ type clusterTestTypeLister struct {
 
 // List lists all ClusterTestTypes in the indexer for a workspace.
 func (s *clusterTestTypeLister) List(selector labels.Selector) (ret []*examplev2.ClusterTestType, err error) {
-	selectAll := selector == nil || selector.Empty()
-
-	list, err := s.indexer.ByIndex(kcpcache.ClusterIndexName, kcpcache.ClusterIndexKey(s.cluster))
-	if err != nil {
-		return nil, err
-	}
-
-	for i := range list {
-		obj := list[i].(*examplev2.ClusterTestType)
-		if selectAll {
-			ret = append(ret, obj)
-		} else {
-			if selector.Matches(labels.Set(obj.GetLabels())) {
-				ret = append(ret, obj)
-			}
-		}
-	}
-
+	err = kcpcache.ListAllByCluster(s.indexer, s.cluster, selector, func(i interface{}) {
+		ret = append(ret, i.(*examplev2.ClusterTestType))
+	})
 	return ret, err
 }
 

--- a/examples/pkg/kcp/clients/listers/example/v2/testtype.go
+++ b/examples/pkg/kcp/clients/listers/example/v2/testtype.go
@@ -26,7 +26,6 @@ import (
 	"github.com/kcp-dev/logicalcluster/v2"
 
 	"k8s.io/apimachinery/pkg/api/errors"
-	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/labels"
 	"k8s.io/client-go/tools/cache"
 
@@ -74,24 +73,9 @@ type testTypeLister struct {
 
 // List lists all TestTypes in the indexer for a workspace.
 func (s *testTypeLister) List(selector labels.Selector) (ret []*examplev2.TestType, err error) {
-	selectAll := selector == nil || selector.Empty()
-
-	list, err := s.indexer.ByIndex(kcpcache.ClusterIndexName, kcpcache.ClusterIndexKey(s.cluster))
-	if err != nil {
-		return nil, err
-	}
-
-	for i := range list {
-		obj := list[i].(*examplev2.TestType)
-		if selectAll {
-			ret = append(ret, obj)
-		} else {
-			if selector.Matches(labels.Set(obj.GetLabels())) {
-				ret = append(ret, obj)
-			}
-		}
-	}
-
+	err = kcpcache.ListAllByCluster(s.indexer, s.cluster, selector, func(i interface{}) {
+		ret = append(ret, i.(*examplev2.TestType))
+	})
 	return ret, err
 }
 
@@ -115,28 +99,9 @@ type testTypeNamespaceLister struct {
 
 // List lists all TestTypes in the indexer for a given workspace and namespace.
 func (s *testTypeNamespaceLister) List(selector labels.Selector) (ret []*examplev2.TestType, err error) {
-	selectAll := selector == nil || selector.Empty()
-
-	var list []interface{}
-	if s.namespace == metav1.NamespaceAll {
-		list, err = s.indexer.ByIndex(kcpcache.ClusterIndexName, kcpcache.ClusterIndexKey(s.cluster))
-	} else {
-		list, err = s.indexer.ByIndex(kcpcache.ClusterAndNamespaceIndexName, kcpcache.ClusterAndNamespaceIndexKey(s.cluster, s.namespace))
-	}
-	if err != nil {
-		return nil, err
-	}
-
-	for i := range list {
-		obj := list[i].(*examplev2.TestType)
-		if selectAll {
-			ret = append(ret, obj)
-		} else {
-			if selector.Matches(labels.Set(obj.GetLabels())) {
-				ret = append(ret, obj)
-			}
-		}
-	}
+	err = kcpcache.ListAllByClusterAndNamespace(s.indexer, s.cluster, s.namespace, selector, func(i interface{}) {
+		ret = append(ret, i.(*examplev2.TestType))
+	})
 	return ret, err
 }
 

--- a/examples/pkg/kcp/clients/listers/example3/v1/clustertesttype.go
+++ b/examples/pkg/kcp/clients/listers/example3/v1/clustertesttype.go
@@ -73,24 +73,9 @@ type clusterTestTypeLister struct {
 
 // List lists all ClusterTestTypes in the indexer for a workspace.
 func (s *clusterTestTypeLister) List(selector labels.Selector) (ret []*example3v1.ClusterTestType, err error) {
-	selectAll := selector == nil || selector.Empty()
-
-	list, err := s.indexer.ByIndex(kcpcache.ClusterIndexName, kcpcache.ClusterIndexKey(s.cluster))
-	if err != nil {
-		return nil, err
-	}
-
-	for i := range list {
-		obj := list[i].(*example3v1.ClusterTestType)
-		if selectAll {
-			ret = append(ret, obj)
-		} else {
-			if selector.Matches(labels.Set(obj.GetLabels())) {
-				ret = append(ret, obj)
-			}
-		}
-	}
-
+	err = kcpcache.ListAllByCluster(s.indexer, s.cluster, selector, func(i interface{}) {
+		ret = append(ret, i.(*example3v1.ClusterTestType))
+	})
 	return ret, err
 }
 

--- a/examples/pkg/kcp/clients/listers/example3/v1/testtype.go
+++ b/examples/pkg/kcp/clients/listers/example3/v1/testtype.go
@@ -26,7 +26,6 @@ import (
 	"github.com/kcp-dev/logicalcluster/v2"
 
 	"k8s.io/apimachinery/pkg/api/errors"
-	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/labels"
 	"k8s.io/client-go/tools/cache"
 
@@ -74,24 +73,9 @@ type testTypeLister struct {
 
 // List lists all TestTypes in the indexer for a workspace.
 func (s *testTypeLister) List(selector labels.Selector) (ret []*example3v1.TestType, err error) {
-	selectAll := selector == nil || selector.Empty()
-
-	list, err := s.indexer.ByIndex(kcpcache.ClusterIndexName, kcpcache.ClusterIndexKey(s.cluster))
-	if err != nil {
-		return nil, err
-	}
-
-	for i := range list {
-		obj := list[i].(*example3v1.TestType)
-		if selectAll {
-			ret = append(ret, obj)
-		} else {
-			if selector.Matches(labels.Set(obj.GetLabels())) {
-				ret = append(ret, obj)
-			}
-		}
-	}
-
+	err = kcpcache.ListAllByCluster(s.indexer, s.cluster, selector, func(i interface{}) {
+		ret = append(ret, i.(*example3v1.TestType))
+	})
 	return ret, err
 }
 
@@ -115,28 +99,9 @@ type testTypeNamespaceLister struct {
 
 // List lists all TestTypes in the indexer for a given workspace and namespace.
 func (s *testTypeNamespaceLister) List(selector labels.Selector) (ret []*example3v1.TestType, err error) {
-	selectAll := selector == nil || selector.Empty()
-
-	var list []interface{}
-	if s.namespace == metav1.NamespaceAll {
-		list, err = s.indexer.ByIndex(kcpcache.ClusterIndexName, kcpcache.ClusterIndexKey(s.cluster))
-	} else {
-		list, err = s.indexer.ByIndex(kcpcache.ClusterAndNamespaceIndexName, kcpcache.ClusterAndNamespaceIndexKey(s.cluster, s.namespace))
-	}
-	if err != nil {
-		return nil, err
-	}
-
-	for i := range list {
-		obj := list[i].(*example3v1.TestType)
-		if selectAll {
-			ret = append(ret, obj)
-		} else {
-			if selector.Matches(labels.Set(obj.GetLabels())) {
-				ret = append(ret, obj)
-			}
-		}
-	}
+	err = kcpcache.ListAllByClusterAndNamespace(s.indexer, s.cluster, s.namespace, selector, func(i interface{}) {
+		ret = append(ret, i.(*example3v1.TestType))
+	})
 	return ret, err
 }
 

--- a/examples/pkg/kcp/clients/listers/existinginterfaces/v1/clustertesttype.go
+++ b/examples/pkg/kcp/clients/listers/existinginterfaces/v1/clustertesttype.go
@@ -73,24 +73,9 @@ type clusterTestTypeLister struct {
 
 // List lists all ClusterTestTypes in the indexer for a workspace.
 func (s *clusterTestTypeLister) List(selector labels.Selector) (ret []*existinginterfacesv1.ClusterTestType, err error) {
-	selectAll := selector == nil || selector.Empty()
-
-	list, err := s.indexer.ByIndex(kcpcache.ClusterIndexName, kcpcache.ClusterIndexKey(s.cluster))
-	if err != nil {
-		return nil, err
-	}
-
-	for i := range list {
-		obj := list[i].(*existinginterfacesv1.ClusterTestType)
-		if selectAll {
-			ret = append(ret, obj)
-		} else {
-			if selector.Matches(labels.Set(obj.GetLabels())) {
-				ret = append(ret, obj)
-			}
-		}
-	}
-
+	err = kcpcache.ListAllByCluster(s.indexer, s.cluster, selector, func(i interface{}) {
+		ret = append(ret, i.(*existinginterfacesv1.ClusterTestType))
+	})
 	return ret, err
 }
 

--- a/examples/pkg/kcp/clients/listers/existinginterfaces/v1/testtype.go
+++ b/examples/pkg/kcp/clients/listers/existinginterfaces/v1/testtype.go
@@ -26,7 +26,6 @@ import (
 	"github.com/kcp-dev/logicalcluster/v2"
 
 	"k8s.io/apimachinery/pkg/api/errors"
-	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/labels"
 	"k8s.io/client-go/tools/cache"
 
@@ -74,24 +73,9 @@ type testTypeLister struct {
 
 // List lists all TestTypes in the indexer for a workspace.
 func (s *testTypeLister) List(selector labels.Selector) (ret []*existinginterfacesv1.TestType, err error) {
-	selectAll := selector == nil || selector.Empty()
-
-	list, err := s.indexer.ByIndex(kcpcache.ClusterIndexName, kcpcache.ClusterIndexKey(s.cluster))
-	if err != nil {
-		return nil, err
-	}
-
-	for i := range list {
-		obj := list[i].(*existinginterfacesv1.TestType)
-		if selectAll {
-			ret = append(ret, obj)
-		} else {
-			if selector.Matches(labels.Set(obj.GetLabels())) {
-				ret = append(ret, obj)
-			}
-		}
-	}
-
+	err = kcpcache.ListAllByCluster(s.indexer, s.cluster, selector, func(i interface{}) {
+		ret = append(ret, i.(*existinginterfacesv1.TestType))
+	})
 	return ret, err
 }
 
@@ -115,28 +99,9 @@ type testTypeNamespaceLister struct {
 
 // List lists all TestTypes in the indexer for a given workspace and namespace.
 func (s *testTypeNamespaceLister) List(selector labels.Selector) (ret []*existinginterfacesv1.TestType, err error) {
-	selectAll := selector == nil || selector.Empty()
-
-	var list []interface{}
-	if s.namespace == metav1.NamespaceAll {
-		list, err = s.indexer.ByIndex(kcpcache.ClusterIndexName, kcpcache.ClusterIndexKey(s.cluster))
-	} else {
-		list, err = s.indexer.ByIndex(kcpcache.ClusterAndNamespaceIndexName, kcpcache.ClusterAndNamespaceIndexKey(s.cluster, s.namespace))
-	}
-	if err != nil {
-		return nil, err
-	}
-
-	for i := range list {
-		obj := list[i].(*existinginterfacesv1.TestType)
-		if selectAll {
-			ret = append(ret, obj)
-		} else {
-			if selector.Matches(labels.Set(obj.GetLabels())) {
-				ret = append(ret, obj)
-			}
-		}
-	}
+	err = kcpcache.ListAllByClusterAndNamespace(s.indexer, s.cluster, s.namespace, selector, func(i interface{}) {
+		ret = append(ret, i.(*existinginterfacesv1.TestType))
+	})
 	return ret, err
 }
 

--- a/examples/pkg/kcp/clients/listers/secondexample/v1/clustertesttype.go
+++ b/examples/pkg/kcp/clients/listers/secondexample/v1/clustertesttype.go
@@ -73,24 +73,9 @@ type clusterTestTypeLister struct {
 
 // List lists all ClusterTestTypes in the indexer for a workspace.
 func (s *clusterTestTypeLister) List(selector labels.Selector) (ret []*secondexamplev1.ClusterTestType, err error) {
-	selectAll := selector == nil || selector.Empty()
-
-	list, err := s.indexer.ByIndex(kcpcache.ClusterIndexName, kcpcache.ClusterIndexKey(s.cluster))
-	if err != nil {
-		return nil, err
-	}
-
-	for i := range list {
-		obj := list[i].(*secondexamplev1.ClusterTestType)
-		if selectAll {
-			ret = append(ret, obj)
-		} else {
-			if selector.Matches(labels.Set(obj.GetLabels())) {
-				ret = append(ret, obj)
-			}
-		}
-	}
-
+	err = kcpcache.ListAllByCluster(s.indexer, s.cluster, selector, func(i interface{}) {
+		ret = append(ret, i.(*secondexamplev1.ClusterTestType))
+	})
 	return ret, err
 }
 

--- a/examples/pkg/kcp/clients/listers/secondexample/v1/testtype.go
+++ b/examples/pkg/kcp/clients/listers/secondexample/v1/testtype.go
@@ -26,7 +26,6 @@ import (
 	"github.com/kcp-dev/logicalcluster/v2"
 
 	"k8s.io/apimachinery/pkg/api/errors"
-	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/labels"
 	"k8s.io/client-go/tools/cache"
 
@@ -74,24 +73,9 @@ type testTypeLister struct {
 
 // List lists all TestTypes in the indexer for a workspace.
 func (s *testTypeLister) List(selector labels.Selector) (ret []*secondexamplev1.TestType, err error) {
-	selectAll := selector == nil || selector.Empty()
-
-	list, err := s.indexer.ByIndex(kcpcache.ClusterIndexName, kcpcache.ClusterIndexKey(s.cluster))
-	if err != nil {
-		return nil, err
-	}
-
-	for i := range list {
-		obj := list[i].(*secondexamplev1.TestType)
-		if selectAll {
-			ret = append(ret, obj)
-		} else {
-			if selector.Matches(labels.Set(obj.GetLabels())) {
-				ret = append(ret, obj)
-			}
-		}
-	}
-
+	err = kcpcache.ListAllByCluster(s.indexer, s.cluster, selector, func(i interface{}) {
+		ret = append(ret, i.(*secondexamplev1.TestType))
+	})
 	return ret, err
 }
 
@@ -115,28 +99,9 @@ type testTypeNamespaceLister struct {
 
 // List lists all TestTypes in the indexer for a given workspace and namespace.
 func (s *testTypeNamespaceLister) List(selector labels.Selector) (ret []*secondexamplev1.TestType, err error) {
-	selectAll := selector == nil || selector.Empty()
-
-	var list []interface{}
-	if s.namespace == metav1.NamespaceAll {
-		list, err = s.indexer.ByIndex(kcpcache.ClusterIndexName, kcpcache.ClusterIndexKey(s.cluster))
-	} else {
-		list, err = s.indexer.ByIndex(kcpcache.ClusterAndNamespaceIndexName, kcpcache.ClusterAndNamespaceIndexKey(s.cluster, s.namespace))
-	}
-	if err != nil {
-		return nil, err
-	}
-
-	for i := range list {
-		obj := list[i].(*secondexamplev1.TestType)
-		if selectAll {
-			ret = append(ret, obj)
-		} else {
-			if selector.Matches(labels.Set(obj.GetLabels())) {
-				ret = append(ret, obj)
-			}
-		}
-	}
+	err = kcpcache.ListAllByClusterAndNamespace(s.indexer, s.cluster, s.namespace, selector, func(i interface{}) {
+		ret = append(ret, i.(*secondexamplev1.TestType))
+	})
 	return ret, err
 }
 

--- a/examples/pkg/kcpexisting/clients/informers/externalversions/factory.go
+++ b/examples/pkg/kcpexisting/clients/informers/externalversions/factory.go
@@ -44,7 +44,12 @@ import (
 )
 
 // SharedInformerOption defines the functional option type for SharedInformerFactory.
-type SharedInformerOption func(*sharedInformerFactory) *sharedInformerFactory
+type SharedInformerOption func(*SharedInformerOptions) *SharedInformerOptions
+
+type SharedInformerOptions struct {
+	customResync     map[reflect.Type]time.Duration
+	tweakListOptions internalinterfaces.TweakListOptionsFunc
+}
 
 type sharedInformerFactory struct {
 	client           clientset.ClusterInterface
@@ -61,19 +66,19 @@ type sharedInformerFactory struct {
 
 // WithCustomResyncConfig sets a custom resync period for the specified informer types.
 func WithCustomResyncConfig(resyncConfig map[metav1.Object]time.Duration) SharedInformerOption {
-	return func(factory *sharedInformerFactory) *sharedInformerFactory {
+	return func(opts *SharedInformerOptions) *SharedInformerOptions {
 		for k, v := range resyncConfig {
-			factory.customResync[reflect.TypeOf(k)] = v
+			opts.customResync[reflect.TypeOf(k)] = v
 		}
-		return factory
+		return opts
 	}
 }
 
 // WithTweakListOptions sets a custom filter on all listers of the configured SharedInformerFactory.
 func WithTweakListOptions(tweakListOptions internalinterfaces.TweakListOptionsFunc) SharedInformerOption {
-	return func(factory *sharedInformerFactory) *sharedInformerFactory {
-		factory.tweakListOptions = tweakListOptions
-		return factory
+	return func(opts *SharedInformerOptions) *SharedInformerOptions {
+		opts.tweakListOptions = tweakListOptions
+		return opts
 	}
 }
 
@@ -92,10 +97,18 @@ func NewSharedInformerFactoryWithOptions(client clientset.ClusterInterface, defa
 		customResync:     make(map[reflect.Type]time.Duration),
 	}
 
+	opts := &SharedInformerOptions{
+		customResync: make(map[reflect.Type]time.Duration),
+	}
+
 	// Apply all options
 	for _, opt := range options {
-		factory = opt(factory)
+		opts = opt(opts)
 	}
+
+	// Forward options to the factory
+	factory.customResync = opts.customResync
+	factory.tweakListOptions = opts.tweakListOptions
 
 	return factory
 }
@@ -135,7 +148,7 @@ func (f *sharedInformerFactory) WaitForCacheSync(stopCh <-chan struct{}) map[ref
 	return res
 }
 
-// InternalInformerFor returns the SharedIndexInformer for obj using an internal
+// InformerFor returns the SharedIndexInformer for obj using an internal
 // client.
 func (f *sharedInformerFactory) InformerFor(obj runtime.Object, newFunc internalinterfaces.NewInformerFunc) kcpcache.ScopeableSharedIndexInformer {
 	f.lock.Lock()

--- a/examples/pkg/kcpexisting/clients/informers/externalversions/internalinterfaces/factory_interfaces.go
+++ b/examples/pkg/kcpexisting/clients/informers/externalversions/internalinterfaces/factory_interfaces.go
@@ -26,14 +26,14 @@ import (
 
 	kcpcache "github.com/kcp-dev/apimachinery/pkg/cache"
 
-	v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	runtime "k8s.io/apimachinery/pkg/runtime"
 
-	client "acme.corp/pkg/kcpexisting/clients/clientset/versioned"
+	clientset "acme.corp/pkg/kcpexisting/clients/clientset/versioned"
 )
 
-// NewInformerFunc takes client.ClusterInterface and time.Duration to return a ScopeableSharedIndexInformer.
-type NewInformerFunc func(client.ClusterInterface, time.Duration) kcpcache.ScopeableSharedIndexInformer
+// NewInformerFunc takes clientset.ClusterInterface and time.Duration to return a ScopeableSharedIndexInformer.
+type NewInformerFunc func(clientset.ClusterInterface, time.Duration) kcpcache.ScopeableSharedIndexInformer
 
 // SharedInformerFactory a small interface to allow for adding an informer without an import cycle
 type SharedInformerFactory interface {
@@ -41,5 +41,5 @@ type SharedInformerFactory interface {
 	InformerFor(obj runtime.Object, newFunc NewInformerFunc) kcpcache.ScopeableSharedIndexInformer
 }
 
-// TweakListOptionsFunc is a function that transforms a v1.ListOptions.
-type TweakListOptionsFunc func(*v1.ListOptions)
+// TweakListOptionsFunc is a function that transforms a metav1.ListOptions.
+type TweakListOptionsFunc func(*metav1.ListOptions)

--- a/examples/pkg/kcpexisting/clients/listers/example/v1/clustertesttype.go
+++ b/examples/pkg/kcpexisting/clients/listers/example/v1/clustertesttype.go
@@ -69,24 +69,9 @@ type clusterTestTypeLister struct {
 
 // List lists all ClusterTestTypes in the indexer for a workspace.
 func (s *clusterTestTypeLister) List(selector labels.Selector) (ret []*examplev1.ClusterTestType, err error) {
-	selectAll := selector == nil || selector.Empty()
-
-	list, err := s.indexer.ByIndex(kcpcache.ClusterIndexName, kcpcache.ClusterIndexKey(s.cluster))
-	if err != nil {
-		return nil, err
-	}
-
-	for i := range list {
-		obj := list[i].(*examplev1.ClusterTestType)
-		if selectAll {
-			ret = append(ret, obj)
-		} else {
-			if selector.Matches(labels.Set(obj.GetLabels())) {
-				ret = append(ret, obj)
-			}
-		}
-	}
-
+	err = kcpcache.ListAllByCluster(s.indexer, s.cluster, selector, func(i interface{}) {
+		ret = append(ret, i.(*examplev1.ClusterTestType))
+	})
 	return ret, err
 }
 

--- a/examples/pkg/kcpexisting/clients/listers/example/v1/testtype.go
+++ b/examples/pkg/kcpexisting/clients/listers/example/v1/testtype.go
@@ -26,7 +26,6 @@ import (
 	"github.com/kcp-dev/logicalcluster/v2"
 
 	"k8s.io/apimachinery/pkg/api/errors"
-	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/labels"
 	"k8s.io/client-go/tools/cache"
 
@@ -70,24 +69,9 @@ type testTypeLister struct {
 
 // List lists all TestTypes in the indexer for a workspace.
 func (s *testTypeLister) List(selector labels.Selector) (ret []*examplev1.TestType, err error) {
-	selectAll := selector == nil || selector.Empty()
-
-	list, err := s.indexer.ByIndex(kcpcache.ClusterIndexName, kcpcache.ClusterIndexKey(s.cluster))
-	if err != nil {
-		return nil, err
-	}
-
-	for i := range list {
-		obj := list[i].(*examplev1.TestType)
-		if selectAll {
-			ret = append(ret, obj)
-		} else {
-			if selector.Matches(labels.Set(obj.GetLabels())) {
-				ret = append(ret, obj)
-			}
-		}
-	}
-
+	err = kcpcache.ListAllByCluster(s.indexer, s.cluster, selector, func(i interface{}) {
+		ret = append(ret, i.(*examplev1.TestType))
+	})
 	return ret, err
 }
 
@@ -105,28 +89,9 @@ type testTypeNamespaceLister struct {
 
 // List lists all TestTypes in the indexer for a given workspace and namespace.
 func (s *testTypeNamespaceLister) List(selector labels.Selector) (ret []*examplev1.TestType, err error) {
-	selectAll := selector == nil || selector.Empty()
-
-	var list []interface{}
-	if s.namespace == metav1.NamespaceAll {
-		list, err = s.indexer.ByIndex(kcpcache.ClusterIndexName, kcpcache.ClusterIndexKey(s.cluster))
-	} else {
-		list, err = s.indexer.ByIndex(kcpcache.ClusterAndNamespaceIndexName, kcpcache.ClusterAndNamespaceIndexKey(s.cluster, s.namespace))
-	}
-	if err != nil {
-		return nil, err
-	}
-
-	for i := range list {
-		obj := list[i].(*examplev1.TestType)
-		if selectAll {
-			ret = append(ret, obj)
-		} else {
-			if selector.Matches(labels.Set(obj.GetLabels())) {
-				ret = append(ret, obj)
-			}
-		}
-	}
+	err = kcpcache.ListAllByClusterAndNamespace(s.indexer, s.cluster, s.namespace, selector, func(i interface{}) {
+		ret = append(ret, i.(*examplev1.TestType))
+	})
 	return ret, err
 }
 

--- a/examples/pkg/kcpexisting/clients/listers/example/v1alpha1/clustertesttype.go
+++ b/examples/pkg/kcpexisting/clients/listers/example/v1alpha1/clustertesttype.go
@@ -69,24 +69,9 @@ type clusterTestTypeLister struct {
 
 // List lists all ClusterTestTypes in the indexer for a workspace.
 func (s *clusterTestTypeLister) List(selector labels.Selector) (ret []*examplev1alpha1.ClusterTestType, err error) {
-	selectAll := selector == nil || selector.Empty()
-
-	list, err := s.indexer.ByIndex(kcpcache.ClusterIndexName, kcpcache.ClusterIndexKey(s.cluster))
-	if err != nil {
-		return nil, err
-	}
-
-	for i := range list {
-		obj := list[i].(*examplev1alpha1.ClusterTestType)
-		if selectAll {
-			ret = append(ret, obj)
-		} else {
-			if selector.Matches(labels.Set(obj.GetLabels())) {
-				ret = append(ret, obj)
-			}
-		}
-	}
-
+	err = kcpcache.ListAllByCluster(s.indexer, s.cluster, selector, func(i interface{}) {
+		ret = append(ret, i.(*examplev1alpha1.ClusterTestType))
+	})
 	return ret, err
 }
 

--- a/examples/pkg/kcpexisting/clients/listers/example/v1alpha1/testtype.go
+++ b/examples/pkg/kcpexisting/clients/listers/example/v1alpha1/testtype.go
@@ -26,7 +26,6 @@ import (
 	"github.com/kcp-dev/logicalcluster/v2"
 
 	"k8s.io/apimachinery/pkg/api/errors"
-	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/labels"
 	"k8s.io/client-go/tools/cache"
 
@@ -70,24 +69,9 @@ type testTypeLister struct {
 
 // List lists all TestTypes in the indexer for a workspace.
 func (s *testTypeLister) List(selector labels.Selector) (ret []*examplev1alpha1.TestType, err error) {
-	selectAll := selector == nil || selector.Empty()
-
-	list, err := s.indexer.ByIndex(kcpcache.ClusterIndexName, kcpcache.ClusterIndexKey(s.cluster))
-	if err != nil {
-		return nil, err
-	}
-
-	for i := range list {
-		obj := list[i].(*examplev1alpha1.TestType)
-		if selectAll {
-			ret = append(ret, obj)
-		} else {
-			if selector.Matches(labels.Set(obj.GetLabels())) {
-				ret = append(ret, obj)
-			}
-		}
-	}
-
+	err = kcpcache.ListAllByCluster(s.indexer, s.cluster, selector, func(i interface{}) {
+		ret = append(ret, i.(*examplev1alpha1.TestType))
+	})
 	return ret, err
 }
 
@@ -105,28 +89,9 @@ type testTypeNamespaceLister struct {
 
 // List lists all TestTypes in the indexer for a given workspace and namespace.
 func (s *testTypeNamespaceLister) List(selector labels.Selector) (ret []*examplev1alpha1.TestType, err error) {
-	selectAll := selector == nil || selector.Empty()
-
-	var list []interface{}
-	if s.namespace == metav1.NamespaceAll {
-		list, err = s.indexer.ByIndex(kcpcache.ClusterIndexName, kcpcache.ClusterIndexKey(s.cluster))
-	} else {
-		list, err = s.indexer.ByIndex(kcpcache.ClusterAndNamespaceIndexName, kcpcache.ClusterAndNamespaceIndexKey(s.cluster, s.namespace))
-	}
-	if err != nil {
-		return nil, err
-	}
-
-	for i := range list {
-		obj := list[i].(*examplev1alpha1.TestType)
-		if selectAll {
-			ret = append(ret, obj)
-		} else {
-			if selector.Matches(labels.Set(obj.GetLabels())) {
-				ret = append(ret, obj)
-			}
-		}
-	}
+	err = kcpcache.ListAllByClusterAndNamespace(s.indexer, s.cluster, s.namespace, selector, func(i interface{}) {
+		ret = append(ret, i.(*examplev1alpha1.TestType))
+	})
 	return ret, err
 }
 

--- a/examples/pkg/kcpexisting/clients/listers/example/v1beta1/clustertesttype.go
+++ b/examples/pkg/kcpexisting/clients/listers/example/v1beta1/clustertesttype.go
@@ -69,24 +69,9 @@ type clusterTestTypeLister struct {
 
 // List lists all ClusterTestTypes in the indexer for a workspace.
 func (s *clusterTestTypeLister) List(selector labels.Selector) (ret []*examplev1beta1.ClusterTestType, err error) {
-	selectAll := selector == nil || selector.Empty()
-
-	list, err := s.indexer.ByIndex(kcpcache.ClusterIndexName, kcpcache.ClusterIndexKey(s.cluster))
-	if err != nil {
-		return nil, err
-	}
-
-	for i := range list {
-		obj := list[i].(*examplev1beta1.ClusterTestType)
-		if selectAll {
-			ret = append(ret, obj)
-		} else {
-			if selector.Matches(labels.Set(obj.GetLabels())) {
-				ret = append(ret, obj)
-			}
-		}
-	}
-
+	err = kcpcache.ListAllByCluster(s.indexer, s.cluster, selector, func(i interface{}) {
+		ret = append(ret, i.(*examplev1beta1.ClusterTestType))
+	})
 	return ret, err
 }
 

--- a/examples/pkg/kcpexisting/clients/listers/example/v2/clustertesttype.go
+++ b/examples/pkg/kcpexisting/clients/listers/example/v2/clustertesttype.go
@@ -69,24 +69,9 @@ type clusterTestTypeLister struct {
 
 // List lists all ClusterTestTypes in the indexer for a workspace.
 func (s *clusterTestTypeLister) List(selector labels.Selector) (ret []*examplev2.ClusterTestType, err error) {
-	selectAll := selector == nil || selector.Empty()
-
-	list, err := s.indexer.ByIndex(kcpcache.ClusterIndexName, kcpcache.ClusterIndexKey(s.cluster))
-	if err != nil {
-		return nil, err
-	}
-
-	for i := range list {
-		obj := list[i].(*examplev2.ClusterTestType)
-		if selectAll {
-			ret = append(ret, obj)
-		} else {
-			if selector.Matches(labels.Set(obj.GetLabels())) {
-				ret = append(ret, obj)
-			}
-		}
-	}
-
+	err = kcpcache.ListAllByCluster(s.indexer, s.cluster, selector, func(i interface{}) {
+		ret = append(ret, i.(*examplev2.ClusterTestType))
+	})
 	return ret, err
 }
 

--- a/examples/pkg/kcpexisting/clients/listers/example/v2/testtype.go
+++ b/examples/pkg/kcpexisting/clients/listers/example/v2/testtype.go
@@ -26,7 +26,6 @@ import (
 	"github.com/kcp-dev/logicalcluster/v2"
 
 	"k8s.io/apimachinery/pkg/api/errors"
-	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/labels"
 	"k8s.io/client-go/tools/cache"
 
@@ -70,24 +69,9 @@ type testTypeLister struct {
 
 // List lists all TestTypes in the indexer for a workspace.
 func (s *testTypeLister) List(selector labels.Selector) (ret []*examplev2.TestType, err error) {
-	selectAll := selector == nil || selector.Empty()
-
-	list, err := s.indexer.ByIndex(kcpcache.ClusterIndexName, kcpcache.ClusterIndexKey(s.cluster))
-	if err != nil {
-		return nil, err
-	}
-
-	for i := range list {
-		obj := list[i].(*examplev2.TestType)
-		if selectAll {
-			ret = append(ret, obj)
-		} else {
-			if selector.Matches(labels.Set(obj.GetLabels())) {
-				ret = append(ret, obj)
-			}
-		}
-	}
-
+	err = kcpcache.ListAllByCluster(s.indexer, s.cluster, selector, func(i interface{}) {
+		ret = append(ret, i.(*examplev2.TestType))
+	})
 	return ret, err
 }
 
@@ -105,28 +89,9 @@ type testTypeNamespaceLister struct {
 
 // List lists all TestTypes in the indexer for a given workspace and namespace.
 func (s *testTypeNamespaceLister) List(selector labels.Selector) (ret []*examplev2.TestType, err error) {
-	selectAll := selector == nil || selector.Empty()
-
-	var list []interface{}
-	if s.namespace == metav1.NamespaceAll {
-		list, err = s.indexer.ByIndex(kcpcache.ClusterIndexName, kcpcache.ClusterIndexKey(s.cluster))
-	} else {
-		list, err = s.indexer.ByIndex(kcpcache.ClusterAndNamespaceIndexName, kcpcache.ClusterAndNamespaceIndexKey(s.cluster, s.namespace))
-	}
-	if err != nil {
-		return nil, err
-	}
-
-	for i := range list {
-		obj := list[i].(*examplev2.TestType)
-		if selectAll {
-			ret = append(ret, obj)
-		} else {
-			if selector.Matches(labels.Set(obj.GetLabels())) {
-				ret = append(ret, obj)
-			}
-		}
-	}
+	err = kcpcache.ListAllByClusterAndNamespace(s.indexer, s.cluster, s.namespace, selector, func(i interface{}) {
+		ret = append(ret, i.(*examplev2.TestType))
+	})
 	return ret, err
 }
 

--- a/examples/pkg/kcpexisting/clients/listers/example3/v1/clustertesttype.go
+++ b/examples/pkg/kcpexisting/clients/listers/example3/v1/clustertesttype.go
@@ -69,24 +69,9 @@ type clusterTestTypeLister struct {
 
 // List lists all ClusterTestTypes in the indexer for a workspace.
 func (s *clusterTestTypeLister) List(selector labels.Selector) (ret []*example3v1.ClusterTestType, err error) {
-	selectAll := selector == nil || selector.Empty()
-
-	list, err := s.indexer.ByIndex(kcpcache.ClusterIndexName, kcpcache.ClusterIndexKey(s.cluster))
-	if err != nil {
-		return nil, err
-	}
-
-	for i := range list {
-		obj := list[i].(*example3v1.ClusterTestType)
-		if selectAll {
-			ret = append(ret, obj)
-		} else {
-			if selector.Matches(labels.Set(obj.GetLabels())) {
-				ret = append(ret, obj)
-			}
-		}
-	}
-
+	err = kcpcache.ListAllByCluster(s.indexer, s.cluster, selector, func(i interface{}) {
+		ret = append(ret, i.(*example3v1.ClusterTestType))
+	})
 	return ret, err
 }
 

--- a/examples/pkg/kcpexisting/clients/listers/existinginterfaces/v1/clustertesttype.go
+++ b/examples/pkg/kcpexisting/clients/listers/existinginterfaces/v1/clustertesttype.go
@@ -69,24 +69,9 @@ type clusterTestTypeLister struct {
 
 // List lists all ClusterTestTypes in the indexer for a workspace.
 func (s *clusterTestTypeLister) List(selector labels.Selector) (ret []*existinginterfacesv1.ClusterTestType, err error) {
-	selectAll := selector == nil || selector.Empty()
-
-	list, err := s.indexer.ByIndex(kcpcache.ClusterIndexName, kcpcache.ClusterIndexKey(s.cluster))
-	if err != nil {
-		return nil, err
-	}
-
-	for i := range list {
-		obj := list[i].(*existinginterfacesv1.ClusterTestType)
-		if selectAll {
-			ret = append(ret, obj)
-		} else {
-			if selector.Matches(labels.Set(obj.GetLabels())) {
-				ret = append(ret, obj)
-			}
-		}
-	}
-
+	err = kcpcache.ListAllByCluster(s.indexer, s.cluster, selector, func(i interface{}) {
+		ret = append(ret, i.(*existinginterfacesv1.ClusterTestType))
+	})
 	return ret, err
 }
 

--- a/examples/pkg/kcpexisting/clients/listers/existinginterfaces/v1/testtype.go
+++ b/examples/pkg/kcpexisting/clients/listers/existinginterfaces/v1/testtype.go
@@ -26,7 +26,6 @@ import (
 	"github.com/kcp-dev/logicalcluster/v2"
 
 	"k8s.io/apimachinery/pkg/api/errors"
-	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/labels"
 	"k8s.io/client-go/tools/cache"
 
@@ -70,24 +69,9 @@ type testTypeLister struct {
 
 // List lists all TestTypes in the indexer for a workspace.
 func (s *testTypeLister) List(selector labels.Selector) (ret []*existinginterfacesv1.TestType, err error) {
-	selectAll := selector == nil || selector.Empty()
-
-	list, err := s.indexer.ByIndex(kcpcache.ClusterIndexName, kcpcache.ClusterIndexKey(s.cluster))
-	if err != nil {
-		return nil, err
-	}
-
-	for i := range list {
-		obj := list[i].(*existinginterfacesv1.TestType)
-		if selectAll {
-			ret = append(ret, obj)
-		} else {
-			if selector.Matches(labels.Set(obj.GetLabels())) {
-				ret = append(ret, obj)
-			}
-		}
-	}
-
+	err = kcpcache.ListAllByCluster(s.indexer, s.cluster, selector, func(i interface{}) {
+		ret = append(ret, i.(*existinginterfacesv1.TestType))
+	})
 	return ret, err
 }
 
@@ -105,28 +89,9 @@ type testTypeNamespaceLister struct {
 
 // List lists all TestTypes in the indexer for a given workspace and namespace.
 func (s *testTypeNamespaceLister) List(selector labels.Selector) (ret []*existinginterfacesv1.TestType, err error) {
-	selectAll := selector == nil || selector.Empty()
-
-	var list []interface{}
-	if s.namespace == metav1.NamespaceAll {
-		list, err = s.indexer.ByIndex(kcpcache.ClusterIndexName, kcpcache.ClusterIndexKey(s.cluster))
-	} else {
-		list, err = s.indexer.ByIndex(kcpcache.ClusterAndNamespaceIndexName, kcpcache.ClusterAndNamespaceIndexKey(s.cluster, s.namespace))
-	}
-	if err != nil {
-		return nil, err
-	}
-
-	for i := range list {
-		obj := list[i].(*existinginterfacesv1.TestType)
-		if selectAll {
-			ret = append(ret, obj)
-		} else {
-			if selector.Matches(labels.Set(obj.GetLabels())) {
-				ret = append(ret, obj)
-			}
-		}
-	}
+	err = kcpcache.ListAllByClusterAndNamespace(s.indexer, s.cluster, s.namespace, selector, func(i interface{}) {
+		ret = append(ret, i.(*existinginterfacesv1.TestType))
+	})
 	return ret, err
 }
 

--- a/examples/pkg/kcpexisting/clients/listers/secondexample/v1/clustertesttype.go
+++ b/examples/pkg/kcpexisting/clients/listers/secondexample/v1/clustertesttype.go
@@ -69,24 +69,9 @@ type clusterTestTypeLister struct {
 
 // List lists all ClusterTestTypes in the indexer for a workspace.
 func (s *clusterTestTypeLister) List(selector labels.Selector) (ret []*secondexamplev1.ClusterTestType, err error) {
-	selectAll := selector == nil || selector.Empty()
-
-	list, err := s.indexer.ByIndex(kcpcache.ClusterIndexName, kcpcache.ClusterIndexKey(s.cluster))
-	if err != nil {
-		return nil, err
-	}
-
-	for i := range list {
-		obj := list[i].(*secondexamplev1.ClusterTestType)
-		if selectAll {
-			ret = append(ret, obj)
-		} else {
-			if selector.Matches(labels.Set(obj.GetLabels())) {
-				ret = append(ret, obj)
-			}
-		}
-	}
-
+	err = kcpcache.ListAllByCluster(s.indexer, s.cluster, selector, func(i interface{}) {
+		ret = append(ret, i.(*secondexamplev1.ClusterTestType))
+	})
 	return ret, err
 }
 

--- a/examples/pkg/kcpexisting/clients/listers/secondexample/v1/testtype.go
+++ b/examples/pkg/kcpexisting/clients/listers/secondexample/v1/testtype.go
@@ -26,7 +26,6 @@ import (
 	"github.com/kcp-dev/logicalcluster/v2"
 
 	"k8s.io/apimachinery/pkg/api/errors"
-	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/labels"
 	"k8s.io/client-go/tools/cache"
 
@@ -70,24 +69,9 @@ type testTypeLister struct {
 
 // List lists all TestTypes in the indexer for a workspace.
 func (s *testTypeLister) List(selector labels.Selector) (ret []*secondexamplev1.TestType, err error) {
-	selectAll := selector == nil || selector.Empty()
-
-	list, err := s.indexer.ByIndex(kcpcache.ClusterIndexName, kcpcache.ClusterIndexKey(s.cluster))
-	if err != nil {
-		return nil, err
-	}
-
-	for i := range list {
-		obj := list[i].(*secondexamplev1.TestType)
-		if selectAll {
-			ret = append(ret, obj)
-		} else {
-			if selector.Matches(labels.Set(obj.GetLabels())) {
-				ret = append(ret, obj)
-			}
-		}
-	}
-
+	err = kcpcache.ListAllByCluster(s.indexer, s.cluster, selector, func(i interface{}) {
+		ret = append(ret, i.(*secondexamplev1.TestType))
+	})
 	return ret, err
 }
 
@@ -105,28 +89,9 @@ type testTypeNamespaceLister struct {
 
 // List lists all TestTypes in the indexer for a given workspace and namespace.
 func (s *testTypeNamespaceLister) List(selector labels.Selector) (ret []*secondexamplev1.TestType, err error) {
-	selectAll := selector == nil || selector.Empty()
-
-	var list []interface{}
-	if s.namespace == metav1.NamespaceAll {
-		list, err = s.indexer.ByIndex(kcpcache.ClusterIndexName, kcpcache.ClusterIndexKey(s.cluster))
-	} else {
-		list, err = s.indexer.ByIndex(kcpcache.ClusterAndNamespaceIndexName, kcpcache.ClusterAndNamespaceIndexKey(s.cluster, s.namespace))
-	}
-	if err != nil {
-		return nil, err
-	}
-
-	for i := range list {
-		obj := list[i].(*secondexamplev1.TestType)
-		if selectAll {
-			ret = append(ret, obj)
-		} else {
-			if selector.Matches(labels.Set(obj.GetLabels())) {
-				ret = append(ret, obj)
-			}
-		}
-	}
+	err = kcpcache.ListAllByClusterAndNamespace(s.indexer, s.cluster, s.namespace, selector, func(i interface{}) {
+		ret = append(ret, i.(*secondexamplev1.TestType))
+	})
 	return ret, err
 }
 

--- a/pkg/internal/informergen/factory.go
+++ b/pkg/internal/informergen/factory.go
@@ -91,7 +91,12 @@ import (
 )
 
 // SharedInformerOption defines the functional option type for SharedInformerFactory.
-type SharedInformerOption func(*sharedInformerFactory) *sharedInformerFactory
+type SharedInformerOption func(*SharedInformerOptions) *SharedInformerOptions
+
+type SharedInformerOptions struct {
+	customResync map[reflect.Type]time.Duration
+	tweakListOptions internalinterfaces.TweakListOptionsFunc
+}
 
 type sharedInformerFactory struct {
 	client clientset.ClusterInterface
@@ -108,19 +113,19 @@ type sharedInformerFactory struct {
 
 // WithCustomResyncConfig sets a custom resync period for the specified informer types.
 func WithCustomResyncConfig(resyncConfig map[metav1.Object]time.Duration) SharedInformerOption {
-	return func(factory *sharedInformerFactory) *sharedInformerFactory {
+	return func(opts *SharedInformerOptions) *SharedInformerOptions {
 		for k, v := range resyncConfig {
-			factory.customResync[reflect.TypeOf(k)] = v
+			opts.customResync[reflect.TypeOf(k)] = v
 		}
-		return factory
+		return opts
 	}
 }
 
 // WithTweakListOptions sets a custom filter on all listers of the configured SharedInformerFactory.
 func WithTweakListOptions(tweakListOptions internalinterfaces.TweakListOptionsFunc) SharedInformerOption {
-	return func(factory *sharedInformerFactory) *sharedInformerFactory {
-		factory.tweakListOptions = tweakListOptions
-		return factory
+	return func(opts *SharedInformerOptions) *SharedInformerOptions {
+		opts.tweakListOptions = tweakListOptions
+		return opts
 	}
 }
 
@@ -139,10 +144,18 @@ func NewSharedInformerFactoryWithOptions(client clientset.ClusterInterface, defa
 		customResync:     make(map[reflect.Type]time.Duration),
 	}
 
+	opts := &SharedInformerOptions{
+		customResync:     make(map[reflect.Type]time.Duration),
+	}
+
 	// Apply all options
 	for _, opt := range options {
-		factory = opt(factory)
+		opts = opt(opts)
 	}
+
+	// Forward options to the factory
+	factory.customResync = opts.customResync
+	factory.tweakListOptions = opts.tweakListOptions
 
 	return factory
 }
@@ -182,7 +195,7 @@ func (f *sharedInformerFactory) WaitForCacheSync(stopCh <-chan struct{}) map[ref
        return res
 }
 
-// InternalInformerFor returns the SharedIndexInformer for obj using an internal
+// InformerFor returns the SharedIndexInformer for obj using an internal
 // client.
 func (f *sharedInformerFactory) InformerFor(obj runtime.Object, newFunc internalinterfaces.NewInformerFunc) kcpcache.ScopeableSharedIndexInformer {
   f.lock.Lock()

--- a/pkg/internal/informergen/factoryinterface.go
+++ b/pkg/internal/informergen/factoryinterface.go
@@ -55,11 +55,11 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	runtime "k8s.io/apimachinery/pkg/runtime"
 
-	client "{{.clientsetPackagePath}}"
+	clientset "{{.clientsetPackagePath}}"
 )
 
-// NewInformerFunc takes client.ClusterInterface and time.Duration to return a ScopeableSharedIndexInformer.
-type NewInformerFunc func(client.ClusterInterface, time.Duration) kcpcache.ScopeableSharedIndexInformer
+// NewInformerFunc takes clientset.ClusterInterface and time.Duration to return a ScopeableSharedIndexInformer.
+type NewInformerFunc func(clientset.ClusterInterface, time.Duration) kcpcache.ScopeableSharedIndexInformer
 
 // SharedInformerFactory a small interface to allow for adding an informer without an import cycle
 type SharedInformerFactory interface {

--- a/pkg/internal/informergen/factoryinterface.go
+++ b/pkg/internal/informergen/factoryinterface.go
@@ -52,7 +52,7 @@ import (
 
 	kcpcache "github.com/kcp-dev/apimachinery/pkg/cache"
 
-	v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	runtime "k8s.io/apimachinery/pkg/runtime"
 
 	client "{{.clientsetPackagePath}}"
@@ -67,6 +67,6 @@ type SharedInformerFactory interface {
 	InformerFor(obj runtime.Object, newFunc NewInformerFunc) kcpcache.ScopeableSharedIndexInformer
 }
 
-// TweakListOptionsFunc is a function that transforms a v1.ListOptions.
-type TweakListOptionsFunc func(*v1.ListOptions)
+// TweakListOptionsFunc is a function that transforms a metav1.ListOptions.
+type TweakListOptionsFunc func(*metav1.ListOptions)
 `


### PR DESCRIPTION
informergen: update import name to something more common

Signed-off-by: Steve Kuznetsov <skuznets@redhat.com>

---

informergen: use a better import name

Signed-off-by: Steve Kuznetsov <skuznets@redhat.com>

---

informergen: use an options struct for options

Signed-off-by: Steve Kuznetsov <skuznets@redhat.com>

---

listergen: use helpers for listing by index

Signed-off-by: Steve Kuznetsov <skuznets@redhat.com>

---

examples: update generated code

Signed-off-by: Steve Kuznetsov <skuznets@redhat.com>

---