### PR TITLE
🌱 Add .prow.yaml, migrate to kcp-prow

### DIFF
--- a/.ci-operator.yaml
+++ b/.ci-operator.yaml
@@ -1,4 +1,0 @@
-build_root_image:
-  namespace: ci
-  name: kcp-dev-build-root
-  tag: "1.19"

--- a/.prow.yaml
+++ b/.prow.yaml
@@ -7,7 +7,7 @@ presubmits:
       preset-goproxy: "true"
     spec:
       containers:
-        - image: docker.io/library/go:1.19.9-alpine
+        - image: ghcr.io/kcp-dev/infra/build:1.19.9-1
           command:
             - make
             - verify-codegen
@@ -34,7 +34,7 @@ presubmits:
       preset-goproxy: "true"
     spec:
       containers:
-        - image: docker.io/library/go:1.19.9-alpine
+        - image: ghcr.io/kcp-dev/infra/build:1.19.9-1
           command:
             - make
             - test

--- a/.prow.yaml
+++ b/.prow.yaml
@@ -21,7 +21,7 @@ presubmits:
       preset-goproxy: "true"
     spec:
       containers:
-        - image: docker.io/library/go:1.19.9-alpine
+        - image: ghcr.io/kcp-dev/infra/build:1.19.9-1
           command:
             - make
             - lint

--- a/.prow.yaml
+++ b/.prow.yaml
@@ -1,0 +1,40 @@
+presubmits:
+  - name: pull-codegenerator-verify
+    always_run: true
+    decorate: true
+    clone_uri: "ssh://git@github.com/kcp-dev/code-generator.git"
+    labels:
+      preset-goproxy: "true"
+    spec:
+      containers:
+        - image: docker.io/library/go:1.19.9-alpine
+          command:
+            - make
+            - verify-codegen
+            - verify-boilerplate
+
+  - name: pull-codegenerator-lint
+    always_run: true
+    decorate: true
+    clone_uri: "ssh://git@github.com/kcp-dev/code-generator.git"
+    labels:
+      preset-goproxy: "true"
+    spec:
+      containers:
+        - image: docker.io/library/go:1.19.9-alpine
+          command:
+            - make
+            - lint
+
+  - name: pull-codegenerator-test
+    always_run: true
+    decorate: true
+    clone_uri: "ssh://git@github.com/kcp-dev/code-generator.git"
+    labels:
+      preset-goproxy: "true"
+    spec:
+      containers:
+        - image: docker.io/library/go:1.19.9-alpine
+          command:
+            - make
+            - test

--- a/.prow.yaml
+++ b/.prow.yaml
@@ -1,5 +1,5 @@
 presubmits:
-  - name: pull-codegenerator-verify
+  - name: pull-code-generator-verify
     always_run: true
     decorate: true
     clone_uri: "ssh://git@github.com/kcp-dev/code-generator.git"
@@ -13,7 +13,7 @@ presubmits:
             - verify-codegen
             - verify-boilerplate
 
-  - name: pull-codegenerator-lint
+  - name: pull-code-generator-lint
     always_run: true
     decorate: true
     clone_uri: "ssh://git@github.com/kcp-dev/code-generator.git"
@@ -26,7 +26,7 @@ presubmits:
             - make
             - lint
 
-  - name: pull-codegenerator-test
+  - name: pull-code-generator-test
     always_run: true
     decorate: true
     clone_uri: "ssh://git@github.com/kcp-dev/code-generator.git"


### PR DESCRIPTION
<!--
Thanks for creating a pull request!

If this is your first time, please make sure to review CONTRIBUTING.MD.

Please copy the appropriate `:text:` or icon to the beginning of your PR title:

:sparkles: ✨ feature
:bug: 🐛 bug fix
:book: 📖 docs
:memo: 📝 proposal
:warning: ⚠️ breaking change
:seedling: 🌱 other/misc
:question: ❓ requires manual review/categorization

-->
## Summary

This PR moves this repository to the new kcp-prow (also see https://github.com/kcp-dev/infra/issues/25). It uses `ghcr.io/kcp-dev/infra/build:1.19.9-1`, a base image we are building from https://github.com/kcp-dev/infra/tree/main/images/build.

Also see https://github.com/openshift/release/pull/39766 for removing this repository from openshift-ci.

## Related issue(s)

Fixes https://github.com/kcp-dev/infra/issues/29
