### PR TITLE
🐛 Add more exceptions to namer

### DIFF
--- a/pkg/parser/types.go
+++ b/pkg/parser/types.go
@@ -67,7 +67,9 @@ func NewKind(kind string, namespaced bool, supportedVerbs sets.Set[string], exte
 		namer: namer.Namer{
 			Finalize: util.UpperFirst,
 			Exceptions: map[string]string{
-				"Endpoints": "Endpoints",
+				"Endpoints":               "Endpoints",
+				"ResourceClaimParameters": "ResourceClaimParameters",
+				"ResourceClassParameters": "ResourceClassParameters",
 			},
 		},
 	}


### PR DESCRIPTION
<!--
Thanks for creating a pull request!

If this is your first time, please make sure to review CONTRIBUTING.MD.

Please copy the appropriate `:text:` or icon to the beginning of your PR title:

:sparkles: ✨ feature
:bug: 🐛 bug fix
:book: 📖 docs
:memo: 📝 proposal
:warning: ⚠️ breaking change
:seedling: 🌱 other/misc
:question: ❓ requires manual review/categorization

-->
## Summary

As part of https://github.com/kcp-dev/client-go/pull/37 I realised we have two new types in k8s.io (going from 1.28 to 1.30) that don't work with the current name generator. We should probably look at re-adopting upstream functionality here, but for now these two new exceptions will work.

## Related issue(s)

Fixes #

## Release Notes

<!--
Please add a release note using the following format:

```release-note
<description of change>
```
-->

```release-note
Add naming exceptions for `ResourceClaimParameters` and `ResourceClassParameters`
```
