### PR TITLE
🐛 Fix groupnames in examples

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -98,6 +98,7 @@ lint: $(GOLANGCI_LINT)
 .PHONY: test
 test:
 	go test ./...
+	cd examples; go test ./...
 
 # Note, running this locally if you have any modified files, even those that are not generated,
 # will result in an error. This target is mostly for CI jobs.

--- a/examples/pkg/apis/example/doc.go
+++ b/examples/pkg/apis/example/doc.go
@@ -15,4 +15,5 @@ limitations under the License.
 */
 
 // +k8s:deepcopy-gen=package,register
+// +groupName=example.dev
 package example

--- a/examples/pkg/apis/example/v1/doc.go
+++ b/examples/pkg/apis/example/v1/doc.go
@@ -15,4 +15,5 @@ limitations under the License.
 */
 
 // +k8s:deepcopy-gen=package,register
+// +groupName=example.dev
 package v1

--- a/examples/pkg/apis/example/v1alpha1/doc.go
+++ b/examples/pkg/apis/example/v1alpha1/doc.go
@@ -15,4 +15,5 @@ limitations under the License.
 */
 
 // +k8s:deepcopy-gen=package,register
+// +groupName=example.dev
 package v1alpha1

--- a/examples/pkg/apis/example/v1beta1/doc.go
+++ b/examples/pkg/apis/example/v1beta1/doc.go
@@ -15,4 +15,5 @@ limitations under the License.
 */
 
 // +k8s:deepcopy-gen=package,register
+// +groupName=example.dev
 package v1beta1

--- a/examples/pkg/apis/example/v2/doc.go
+++ b/examples/pkg/apis/example/v2/doc.go
@@ -15,4 +15,5 @@ limitations under the License.
 */
 
 // +k8s:deepcopy-gen=package,register
+// +groupName=example.dev
 package v2

--- a/examples/pkg/apis/example3/register.go
+++ b/examples/pkg/apis/example3/register.go
@@ -17,5 +17,5 @@ limitations under the License.
 package example
 
 const (
-	GroupName = "example3.dev"
+	GroupName = "example3.some.corp"
 )

--- a/examples/pkg/apis/existinginterfaces/register.go
+++ b/examples/pkg/apis/existinginterfaces/register.go
@@ -17,5 +17,5 @@ limitations under the License.
 package existinginterfaces
 
 const (
-	GroupName = "existinginterfaces.dev"
+	GroupName = "existinginterfaces.acme.corp"
 )

--- a/examples/pkg/apis/secondexample/v1/doc.go
+++ b/examples/pkg/apis/secondexample/v1/doc.go
@@ -15,4 +15,5 @@ limitations under the License.
 */
 
 // +k8s:deepcopy-gen=package,register
+// +groupName=secondexample.dev
 package v1

--- a/examples/pkg/generated/applyconfigurations/example/v1/clustertesttype.go
+++ b/examples/pkg/generated/applyconfigurations/example/v1/clustertesttype.go
@@ -40,7 +40,7 @@ func ClusterTestType(name string) *ClusterTestTypeApplyConfiguration {
 	b := &ClusterTestTypeApplyConfiguration{}
 	b.WithName(name)
 	b.WithKind("ClusterTestType")
-	b.WithAPIVersion("example/v1")
+	b.WithAPIVersion("example.dev/v1")
 	return b
 }
 

--- a/examples/pkg/generated/applyconfigurations/example/v1/testtype.go
+++ b/examples/pkg/generated/applyconfigurations/example/v1/testtype.go
@@ -39,7 +39,7 @@ func TestType(name, namespace string) *TestTypeApplyConfiguration {
 	b.WithName(name)
 	b.WithNamespace(namespace)
 	b.WithKind("TestType")
-	b.WithAPIVersion("example/v1")
+	b.WithAPIVersion("example.dev/v1")
 	return b
 }
 

--- a/examples/pkg/generated/applyconfigurations/example/v1/withoutverbtype.go
+++ b/examples/pkg/generated/applyconfigurations/example/v1/withoutverbtype.go
@@ -38,7 +38,7 @@ func WithoutVerbType(name, namespace string) *WithoutVerbTypeApplyConfiguration 
 	b.WithName(name)
 	b.WithNamespace(namespace)
 	b.WithKind("WithoutVerbType")
-	b.WithAPIVersion("example/v1")
+	b.WithAPIVersion("example.dev/v1")
 	return b
 }
 

--- a/examples/pkg/generated/applyconfigurations/example/v1alpha1/clustertesttype.go
+++ b/examples/pkg/generated/applyconfigurations/example/v1alpha1/clustertesttype.go
@@ -40,7 +40,7 @@ func ClusterTestType(name string) *ClusterTestTypeApplyConfiguration {
 	b := &ClusterTestTypeApplyConfiguration{}
 	b.WithName(name)
 	b.WithKind("ClusterTestType")
-	b.WithAPIVersion("example/v1alpha1")
+	b.WithAPIVersion("example.dev/v1alpha1")
 	return b
 }
 

--- a/examples/pkg/generated/applyconfigurations/example/v1alpha1/testtype.go
+++ b/examples/pkg/generated/applyconfigurations/example/v1alpha1/testtype.go
@@ -39,7 +39,7 @@ func TestType(name, namespace string) *TestTypeApplyConfiguration {
 	b.WithName(name)
 	b.WithNamespace(namespace)
 	b.WithKind("TestType")
-	b.WithAPIVersion("example/v1alpha1")
+	b.WithAPIVersion("example.dev/v1alpha1")
 	return b
 }
 

--- a/examples/pkg/generated/applyconfigurations/example/v1beta1/clustertesttype.go
+++ b/examples/pkg/generated/applyconfigurations/example/v1beta1/clustertesttype.go
@@ -40,7 +40,7 @@ func ClusterTestType(name string) *ClusterTestTypeApplyConfiguration {
 	b := &ClusterTestTypeApplyConfiguration{}
 	b.WithName(name)
 	b.WithKind("ClusterTestType")
-	b.WithAPIVersion("example/v1beta1")
+	b.WithAPIVersion("example.dev/v1beta1")
 	return b
 }
 

--- a/examples/pkg/generated/applyconfigurations/example/v1beta1/testtype.go
+++ b/examples/pkg/generated/applyconfigurations/example/v1beta1/testtype.go
@@ -39,7 +39,7 @@ func TestType(name, namespace string) *TestTypeApplyConfiguration {
 	b.WithName(name)
 	b.WithNamespace(namespace)
 	b.WithKind("TestType")
-	b.WithAPIVersion("example/v1beta1")
+	b.WithAPIVersion("example.dev/v1beta1")
 	return b
 }
 

--- a/examples/pkg/generated/applyconfigurations/example/v2/clustertesttype.go
+++ b/examples/pkg/generated/applyconfigurations/example/v2/clustertesttype.go
@@ -40,7 +40,7 @@ func ClusterTestType(name string) *ClusterTestTypeApplyConfiguration {
 	b := &ClusterTestTypeApplyConfiguration{}
 	b.WithName(name)
 	b.WithKind("ClusterTestType")
-	b.WithAPIVersion("example/v2")
+	b.WithAPIVersion("example.dev/v2")
 	return b
 }
 

--- a/examples/pkg/generated/applyconfigurations/example/v2/testtype.go
+++ b/examples/pkg/generated/applyconfigurations/example/v2/testtype.go
@@ -39,7 +39,7 @@ func TestType(name, namespace string) *TestTypeApplyConfiguration {
 	b.WithName(name)
 	b.WithNamespace(namespace)
 	b.WithKind("TestType")
-	b.WithAPIVersion("example/v2")
+	b.WithAPIVersion("example.dev/v2")
 	return b
 }
 

--- a/examples/pkg/generated/applyconfigurations/secondexample/v1/clustertesttype.go
+++ b/examples/pkg/generated/applyconfigurations/secondexample/v1/clustertesttype.go
@@ -40,7 +40,7 @@ func ClusterTestType(name string) *ClusterTestTypeApplyConfiguration {
 	b := &ClusterTestTypeApplyConfiguration{}
 	b.WithName(name)
 	b.WithKind("ClusterTestType")
-	b.WithAPIVersion("secondexample/v1")
+	b.WithAPIVersion("secondexample.dev/v1")
 	return b
 }
 

--- a/examples/pkg/generated/applyconfigurations/secondexample/v1/testtype.go
+++ b/examples/pkg/generated/applyconfigurations/secondexample/v1/testtype.go
@@ -39,7 +39,7 @@ func TestType(name, namespace string) *TestTypeApplyConfiguration {
 	b.WithName(name)
 	b.WithNamespace(namespace)
 	b.WithKind("TestType")
-	b.WithAPIVersion("secondexample/v1")
+	b.WithAPIVersion("secondexample.dev/v1")
 	return b
 }
 

--- a/examples/pkg/generated/applyconfigurations/utils.go
+++ b/examples/pkg/generated/applyconfigurations/utils.go
@@ -23,20 +23,20 @@ import (
 	schema "k8s.io/apimachinery/pkg/runtime/schema"
 	testing "k8s.io/client-go/testing"
 
-	v1 "acme.corp/pkg/apis/example/v1"
+	examplev1 "acme.corp/pkg/apis/example/v1"
 	v1alpha1 "acme.corp/pkg/apis/example/v1alpha1"
 	v1beta1 "acme.corp/pkg/apis/example/v1beta1"
 	v2 "acme.corp/pkg/apis/example/v2"
 	example3v1 "acme.corp/pkg/apis/example3/v1"
-	exampledashedv1 "acme.corp/pkg/apis/exampledashed/v1"
+	v1 "acme.corp/pkg/apis/exampledashed/v1"
 	existinginterfacesv1 "acme.corp/pkg/apis/existinginterfaces/v1"
 	secondexamplev1 "acme.corp/pkg/apis/secondexample/v1"
-	examplev1 "acme.corp/pkg/generated/applyconfigurations/example/v1"
+	applyconfigurationsexamplev1 "acme.corp/pkg/generated/applyconfigurations/example/v1"
 	examplev1alpha1 "acme.corp/pkg/generated/applyconfigurations/example/v1alpha1"
 	examplev1beta1 "acme.corp/pkg/generated/applyconfigurations/example/v1beta1"
 	examplev2 "acme.corp/pkg/generated/applyconfigurations/example/v2"
 	applyconfigurationsexample3v1 "acme.corp/pkg/generated/applyconfigurations/example3/v1"
-	applyconfigurationsexampledashedv1 "acme.corp/pkg/generated/applyconfigurations/exampledashed/v1"
+	exampledashedv1 "acme.corp/pkg/generated/applyconfigurations/exampledashed/v1"
 	applyconfigurationsexistinginterfacesv1 "acme.corp/pkg/generated/applyconfigurations/existinginterfaces/v1"
 	internal "acme.corp/pkg/generated/applyconfigurations/internal"
 	applyconfigurationssecondexamplev1 "acme.corp/pkg/generated/applyconfigurations/secondexample/v1"
@@ -46,17 +46,25 @@ import (
 // apply configuration type exists for the given GroupVersionKind.
 func ForKind(kind schema.GroupVersionKind) interface{} {
 	switch kind {
-	// Group=example, Version=v1
+	// Group=example-dashed.some.corp, Version=v1
 	case v1.SchemeGroupVersion.WithKind("ClusterTestType"):
-		return &examplev1.ClusterTestTypeApplyConfiguration{}
+		return &exampledashedv1.ClusterTestTypeApplyConfiguration{}
 	case v1.SchemeGroupVersion.WithKind("ClusterTestTypeStatus"):
-		return &examplev1.ClusterTestTypeStatusApplyConfiguration{}
+		return &exampledashedv1.ClusterTestTypeStatusApplyConfiguration{}
 	case v1.SchemeGroupVersion.WithKind("TestType"):
-		return &examplev1.TestTypeApplyConfiguration{}
-	case v1.SchemeGroupVersion.WithKind("WithoutVerbType"):
-		return &examplev1.WithoutVerbTypeApplyConfiguration{}
+		return &exampledashedv1.TestTypeApplyConfiguration{}
 
-		// Group=example, Version=v1alpha1
+		// Group=example.dev, Version=v1
+	case examplev1.SchemeGroupVersion.WithKind("ClusterTestType"):
+		return &applyconfigurationsexamplev1.ClusterTestTypeApplyConfiguration{}
+	case examplev1.SchemeGroupVersion.WithKind("ClusterTestTypeStatus"):
+		return &applyconfigurationsexamplev1.ClusterTestTypeStatusApplyConfiguration{}
+	case examplev1.SchemeGroupVersion.WithKind("TestType"):
+		return &applyconfigurationsexamplev1.TestTypeApplyConfiguration{}
+	case examplev1.SchemeGroupVersion.WithKind("WithoutVerbType"):
+		return &applyconfigurationsexamplev1.WithoutVerbTypeApplyConfiguration{}
+
+		// Group=example.dev, Version=v1alpha1
 	case v1alpha1.SchemeGroupVersion.WithKind("ClusterTestType"):
 		return &examplev1alpha1.ClusterTestTypeApplyConfiguration{}
 	case v1alpha1.SchemeGroupVersion.WithKind("ClusterTestTypeStatus"):
@@ -64,7 +72,7 @@ func ForKind(kind schema.GroupVersionKind) interface{} {
 	case v1alpha1.SchemeGroupVersion.WithKind("TestType"):
 		return &examplev1alpha1.TestTypeApplyConfiguration{}
 
-		// Group=example, Version=v1beta1
+		// Group=example.dev, Version=v1beta1
 	case v1beta1.SchemeGroupVersion.WithKind("ClusterTestType"):
 		return &examplev1beta1.ClusterTestTypeApplyConfiguration{}
 	case v1beta1.SchemeGroupVersion.WithKind("ClusterTestTypeStatus"):
@@ -72,21 +80,13 @@ func ForKind(kind schema.GroupVersionKind) interface{} {
 	case v1beta1.SchemeGroupVersion.WithKind("TestType"):
 		return &examplev1beta1.TestTypeApplyConfiguration{}
 
-		// Group=example, Version=v2
+		// Group=example.dev, Version=v2
 	case v2.SchemeGroupVersion.WithKind("ClusterTestType"):
 		return &examplev2.ClusterTestTypeApplyConfiguration{}
 	case v2.SchemeGroupVersion.WithKind("ClusterTestTypeStatus"):
 		return &examplev2.ClusterTestTypeStatusApplyConfiguration{}
 	case v2.SchemeGroupVersion.WithKind("TestType"):
 		return &examplev2.TestTypeApplyConfiguration{}
-
-		// Group=example-dashed.some.corp, Version=v1
-	case exampledashedv1.SchemeGroupVersion.WithKind("ClusterTestType"):
-		return &applyconfigurationsexampledashedv1.ClusterTestTypeApplyConfiguration{}
-	case exampledashedv1.SchemeGroupVersion.WithKind("ClusterTestTypeStatus"):
-		return &applyconfigurationsexampledashedv1.ClusterTestTypeStatusApplyConfiguration{}
-	case exampledashedv1.SchemeGroupVersion.WithKind("TestType"):
-		return &applyconfigurationsexampledashedv1.TestTypeApplyConfiguration{}
 
 		// Group=example3.some.corp, Version=v1
 	case example3v1.SchemeGroupVersion.WithKind("ClusterTestType"):
@@ -104,7 +104,7 @@ func ForKind(kind schema.GroupVersionKind) interface{} {
 	case existinginterfacesv1.SchemeGroupVersion.WithKind("TestType"):
 		return &applyconfigurationsexistinginterfacesv1.TestTypeApplyConfiguration{}
 
-		// Group=secondexample, Version=v1
+		// Group=secondexample.dev, Version=v1
 	case secondexamplev1.SchemeGroupVersion.WithKind("ClusterTestType"):
 		return &applyconfigurationssecondexamplev1.ClusterTestTypeApplyConfiguration{}
 	case secondexamplev1.SchemeGroupVersion.WithKind("ClusterTestTypeStatus"):

--- a/examples/pkg/generated/clientset/versioned/typed/example/v1/example_client.go
+++ b/examples/pkg/generated/clientset/versioned/typed/example/v1/example_client.go
@@ -34,7 +34,7 @@ type ExampleV1Interface interface {
 	WithoutVerbTypesGetter
 }
 
-// ExampleV1Client is used to interact with features provided by the example group.
+// ExampleV1Client is used to interact with features provided by the example.dev group.
 type ExampleV1Client struct {
 	restClient rest.Interface
 }

--- a/examples/pkg/generated/clientset/versioned/typed/example/v1alpha1/example_client.go
+++ b/examples/pkg/generated/clientset/versioned/typed/example/v1alpha1/example_client.go
@@ -33,7 +33,7 @@ type ExampleV1alpha1Interface interface {
 	TestTypesGetter
 }
 
-// ExampleV1alpha1Client is used to interact with features provided by the example group.
+// ExampleV1alpha1Client is used to interact with features provided by the example.dev group.
 type ExampleV1alpha1Client struct {
 	restClient rest.Interface
 }

--- a/examples/pkg/generated/clientset/versioned/typed/example/v1beta1/example_client.go
+++ b/examples/pkg/generated/clientset/versioned/typed/example/v1beta1/example_client.go
@@ -33,7 +33,7 @@ type ExampleV1beta1Interface interface {
 	TestTypesGetter
 }
 
-// ExampleV1beta1Client is used to interact with features provided by the example group.
+// ExampleV1beta1Client is used to interact with features provided by the example.dev group.
 type ExampleV1beta1Client struct {
 	restClient rest.Interface
 }

--- a/examples/pkg/generated/clientset/versioned/typed/example/v2/example_client.go
+++ b/examples/pkg/generated/clientset/versioned/typed/example/v2/example_client.go
@@ -33,7 +33,7 @@ type ExampleV2Interface interface {
 	TestTypesGetter
 }
 
-// ExampleV2Client is used to interact with features provided by the example group.
+// ExampleV2Client is used to interact with features provided by the example.dev group.
 type ExampleV2Client struct {
 	restClient rest.Interface
 }

--- a/examples/pkg/generated/clientset/versioned/typed/secondexample/v1/secondexample_client.go
+++ b/examples/pkg/generated/clientset/versioned/typed/secondexample/v1/secondexample_client.go
@@ -33,7 +33,7 @@ type SecondexampleV1Interface interface {
 	TestTypesGetter
 }
 
-// SecondexampleV1Client is used to interact with features provided by the secondexample group.
+// SecondexampleV1Client is used to interact with features provided by the secondexample.dev group.
 type SecondexampleV1Client struct {
 	restClient rest.Interface
 }

--- a/examples/pkg/generated/informers/externalversions/generic.go
+++ b/examples/pkg/generated/informers/externalversions/generic.go
@@ -24,12 +24,12 @@ import (
 	schema "k8s.io/apimachinery/pkg/runtime/schema"
 	cache "k8s.io/client-go/tools/cache"
 
-	v1 "acme.corp/pkg/apis/example/v1"
+	examplev1 "acme.corp/pkg/apis/example/v1"
 	v1alpha1 "acme.corp/pkg/apis/example/v1alpha1"
 	v1beta1 "acme.corp/pkg/apis/example/v1beta1"
 	v2 "acme.corp/pkg/apis/example/v2"
 	example3v1 "acme.corp/pkg/apis/example3/v1"
-	exampledashedv1 "acme.corp/pkg/apis/exampledashed/v1"
+	v1 "acme.corp/pkg/apis/exampledashed/v1"
 	existinginterfacesv1 "acme.corp/pkg/apis/existinginterfaces/v1"
 	secondexamplev1 "acme.corp/pkg/apis/secondexample/v1"
 )
@@ -60,35 +60,35 @@ func (f *genericInformer) Lister() cache.GenericLister {
 // TODO extend this to unknown resources with a client pool
 func (f *sharedInformerFactory) ForResource(resource schema.GroupVersionResource) (GenericInformer, error) {
 	switch resource {
-	// Group=example, Version=v1
+	// Group=example-dashed.some.corp, Version=v1
 	case v1.SchemeGroupVersion.WithResource("clustertesttypes"):
-		return &genericInformer{resource: resource.GroupResource(), informer: f.Example().V1().ClusterTestTypes().Informer()}, nil
+		return &genericInformer{resource: resource.GroupResource(), informer: f.ExampleDashed().V1().ClusterTestTypes().Informer()}, nil
 	case v1.SchemeGroupVersion.WithResource("testtypes"):
+		return &genericInformer{resource: resource.GroupResource(), informer: f.ExampleDashed().V1().TestTypes().Informer()}, nil
+
+		// Group=example.dev, Version=v1
+	case examplev1.SchemeGroupVersion.WithResource("clustertesttypes"):
+		return &genericInformer{resource: resource.GroupResource(), informer: f.Example().V1().ClusterTestTypes().Informer()}, nil
+	case examplev1.SchemeGroupVersion.WithResource("testtypes"):
 		return &genericInformer{resource: resource.GroupResource(), informer: f.Example().V1().TestTypes().Informer()}, nil
 
-		// Group=example, Version=v1alpha1
+		// Group=example.dev, Version=v1alpha1
 	case v1alpha1.SchemeGroupVersion.WithResource("clustertesttypes"):
 		return &genericInformer{resource: resource.GroupResource(), informer: f.Example().V1alpha1().ClusterTestTypes().Informer()}, nil
 	case v1alpha1.SchemeGroupVersion.WithResource("testtypes"):
 		return &genericInformer{resource: resource.GroupResource(), informer: f.Example().V1alpha1().TestTypes().Informer()}, nil
 
-		// Group=example, Version=v1beta1
+		// Group=example.dev, Version=v1beta1
 	case v1beta1.SchemeGroupVersion.WithResource("clustertesttypes"):
 		return &genericInformer{resource: resource.GroupResource(), informer: f.Example().V1beta1().ClusterTestTypes().Informer()}, nil
 	case v1beta1.SchemeGroupVersion.WithResource("testtypes"):
 		return &genericInformer{resource: resource.GroupResource(), informer: f.Example().V1beta1().TestTypes().Informer()}, nil
 
-		// Group=example, Version=v2
+		// Group=example.dev, Version=v2
 	case v2.SchemeGroupVersion.WithResource("clustertesttypes"):
 		return &genericInformer{resource: resource.GroupResource(), informer: f.Example().V2().ClusterTestTypes().Informer()}, nil
 	case v2.SchemeGroupVersion.WithResource("testtypes"):
 		return &genericInformer{resource: resource.GroupResource(), informer: f.Example().V2().TestTypes().Informer()}, nil
-
-		// Group=example-dashed.some.corp, Version=v1
-	case exampledashedv1.SchemeGroupVersion.WithResource("clustertesttypes"):
-		return &genericInformer{resource: resource.GroupResource(), informer: f.ExampleDashed().V1().ClusterTestTypes().Informer()}, nil
-	case exampledashedv1.SchemeGroupVersion.WithResource("testtypes"):
-		return &genericInformer{resource: resource.GroupResource(), informer: f.ExampleDashed().V1().TestTypes().Informer()}, nil
 
 		// Group=example3.some.corp, Version=v1
 	case example3v1.SchemeGroupVersion.WithResource("clustertesttypes"):
@@ -102,7 +102,7 @@ func (f *sharedInformerFactory) ForResource(resource schema.GroupVersionResource
 	case existinginterfacesv1.SchemeGroupVersion.WithResource("testtypes"):
 		return &genericInformer{resource: resource.GroupResource(), informer: f.Existinginterfaces().V1().TestTypes().Informer()}, nil
 
-		// Group=secondexample, Version=v1
+		// Group=secondexample.dev, Version=v1
 	case secondexamplev1.SchemeGroupVersion.WithResource("clustertesttypes"):
 		return &genericInformer{resource: resource.GroupResource(), informer: f.Secondexample().V1().ClusterTestTypes().Informer()}, nil
 	case secondexamplev1.SchemeGroupVersion.WithResource("testtypes"):

--- a/examples/pkg/kcp/clients/clientset/versioned/typed/example/v1/fake/clustertesttype.go
+++ b/examples/pkg/kcp/clients/clientset/versioned/typed/example/v1/fake/clustertesttype.go
@@ -38,8 +38,8 @@ import (
 	examplev1client "acme.corp/pkg/generated/clientset/versioned/typed/example/v1"
 )
 
-var clusterTestTypesResource = schema.GroupVersionResource{Group: "example", Version: "v1", Resource: "clustertesttypes"}
-var clusterTestTypesKind = schema.GroupVersionKind{Group: "example", Version: "v1", Kind: "ClusterTestType"}
+var clusterTestTypesResource = schema.GroupVersionResource{Group: "example.dev", Version: "v1", Resource: "clustertesttypes"}
+var clusterTestTypesKind = schema.GroupVersionKind{Group: "example.dev", Version: "v1", Kind: "ClusterTestType"}
 
 type clusterTestTypesClusterClient struct {
 	*kcptesting.Fake

--- a/examples/pkg/kcp/clients/clientset/versioned/typed/example/v1/fake/testtype.go
+++ b/examples/pkg/kcp/clients/clientset/versioned/typed/example/v1/fake/testtype.go
@@ -39,8 +39,8 @@ import (
 	kcpexamplev1 "acme.corp/pkg/kcp/clients/clientset/versioned/typed/example/v1"
 )
 
-var testTypesResource = schema.GroupVersionResource{Group: "example", Version: "v1", Resource: "testtypes"}
-var testTypesKind = schema.GroupVersionKind{Group: "example", Version: "v1", Kind: "TestType"}
+var testTypesResource = schema.GroupVersionResource{Group: "example.dev", Version: "v1", Resource: "testtypes"}
+var testTypesKind = schema.GroupVersionKind{Group: "example.dev", Version: "v1", Kind: "TestType"}
 
 type testTypesClusterClient struct {
 	*kcptesting.Fake

--- a/examples/pkg/kcp/clients/clientset/versioned/typed/example/v1/fake/withoutverbtype.go
+++ b/examples/pkg/kcp/clients/clientset/versioned/typed/example/v1/fake/withoutverbtype.go
@@ -28,8 +28,8 @@ import (
 	kcpexamplev1 "acme.corp/pkg/kcp/clients/clientset/versioned/typed/example/v1"
 )
 
-var withoutVerbTypesResource = schema.GroupVersionResource{Group: "example", Version: "v1", Resource: "withoutverbtypes"}
-var withoutVerbTypesKind = schema.GroupVersionKind{Group: "example", Version: "v1", Kind: "WithoutVerbType"}
+var withoutVerbTypesResource = schema.GroupVersionResource{Group: "example.dev", Version: "v1", Resource: "withoutverbtypes"}
+var withoutVerbTypesKind = schema.GroupVersionKind{Group: "example.dev", Version: "v1", Kind: "WithoutVerbType"}
 
 type withoutVerbTypesClusterClient struct {
 	*kcptesting.Fake

--- a/examples/pkg/kcp/clients/clientset/versioned/typed/example/v1alpha1/fake/clustertesttype.go
+++ b/examples/pkg/kcp/clients/clientset/versioned/typed/example/v1alpha1/fake/clustertesttype.go
@@ -38,8 +38,8 @@ import (
 	examplev1alpha1client "acme.corp/pkg/generated/clientset/versioned/typed/example/v1alpha1"
 )
 
-var clusterTestTypesResource = schema.GroupVersionResource{Group: "example", Version: "v1alpha1", Resource: "clustertesttypes"}
-var clusterTestTypesKind = schema.GroupVersionKind{Group: "example", Version: "v1alpha1", Kind: "ClusterTestType"}
+var clusterTestTypesResource = schema.GroupVersionResource{Group: "example.dev", Version: "v1alpha1", Resource: "clustertesttypes"}
+var clusterTestTypesKind = schema.GroupVersionKind{Group: "example.dev", Version: "v1alpha1", Kind: "ClusterTestType"}
 
 type clusterTestTypesClusterClient struct {
 	*kcptesting.Fake

--- a/examples/pkg/kcp/clients/clientset/versioned/typed/example/v1alpha1/fake/testtype.go
+++ b/examples/pkg/kcp/clients/clientset/versioned/typed/example/v1alpha1/fake/testtype.go
@@ -39,8 +39,8 @@ import (
 	kcpexamplev1alpha1 "acme.corp/pkg/kcp/clients/clientset/versioned/typed/example/v1alpha1"
 )
 
-var testTypesResource = schema.GroupVersionResource{Group: "example", Version: "v1alpha1", Resource: "testtypes"}
-var testTypesKind = schema.GroupVersionKind{Group: "example", Version: "v1alpha1", Kind: "TestType"}
+var testTypesResource = schema.GroupVersionResource{Group: "example.dev", Version: "v1alpha1", Resource: "testtypes"}
+var testTypesKind = schema.GroupVersionKind{Group: "example.dev", Version: "v1alpha1", Kind: "TestType"}
 
 type testTypesClusterClient struct {
 	*kcptesting.Fake

--- a/examples/pkg/kcp/clients/clientset/versioned/typed/example/v1beta1/fake/clustertesttype.go
+++ b/examples/pkg/kcp/clients/clientset/versioned/typed/example/v1beta1/fake/clustertesttype.go
@@ -38,8 +38,8 @@ import (
 	examplev1beta1client "acme.corp/pkg/generated/clientset/versioned/typed/example/v1beta1"
 )
 
-var clusterTestTypesResource = schema.GroupVersionResource{Group: "example", Version: "v1beta1", Resource: "clustertesttypes"}
-var clusterTestTypesKind = schema.GroupVersionKind{Group: "example", Version: "v1beta1", Kind: "ClusterTestType"}
+var clusterTestTypesResource = schema.GroupVersionResource{Group: "example.dev", Version: "v1beta1", Resource: "clustertesttypes"}
+var clusterTestTypesKind = schema.GroupVersionKind{Group: "example.dev", Version: "v1beta1", Kind: "ClusterTestType"}
 
 type clusterTestTypesClusterClient struct {
 	*kcptesting.Fake

--- a/examples/pkg/kcp/clients/clientset/versioned/typed/example/v1beta1/fake/testtype.go
+++ b/examples/pkg/kcp/clients/clientset/versioned/typed/example/v1beta1/fake/testtype.go
@@ -39,8 +39,8 @@ import (
 	kcpexamplev1beta1 "acme.corp/pkg/kcp/clients/clientset/versioned/typed/example/v1beta1"
 )
 
-var testTypesResource = schema.GroupVersionResource{Group: "example", Version: "v1beta1", Resource: "testtypes"}
-var testTypesKind = schema.GroupVersionKind{Group: "example", Version: "v1beta1", Kind: "TestType"}
+var testTypesResource = schema.GroupVersionResource{Group: "example.dev", Version: "v1beta1", Resource: "testtypes"}
+var testTypesKind = schema.GroupVersionKind{Group: "example.dev", Version: "v1beta1", Kind: "TestType"}
 
 type testTypesClusterClient struct {
 	*kcptesting.Fake

--- a/examples/pkg/kcp/clients/clientset/versioned/typed/example/v2/fake/clustertesttype.go
+++ b/examples/pkg/kcp/clients/clientset/versioned/typed/example/v2/fake/clustertesttype.go
@@ -38,8 +38,8 @@ import (
 	examplev2client "acme.corp/pkg/generated/clientset/versioned/typed/example/v2"
 )
 
-var clusterTestTypesResource = schema.GroupVersionResource{Group: "example", Version: "v2", Resource: "clustertesttypes"}
-var clusterTestTypesKind = schema.GroupVersionKind{Group: "example", Version: "v2", Kind: "ClusterTestType"}
+var clusterTestTypesResource = schema.GroupVersionResource{Group: "example.dev", Version: "v2", Resource: "clustertesttypes"}
+var clusterTestTypesKind = schema.GroupVersionKind{Group: "example.dev", Version: "v2", Kind: "ClusterTestType"}
 
 type clusterTestTypesClusterClient struct {
 	*kcptesting.Fake

--- a/examples/pkg/kcp/clients/clientset/versioned/typed/example/v2/fake/testtype.go
+++ b/examples/pkg/kcp/clients/clientset/versioned/typed/example/v2/fake/testtype.go
@@ -39,8 +39,8 @@ import (
 	kcpexamplev2 "acme.corp/pkg/kcp/clients/clientset/versioned/typed/example/v2"
 )
 
-var testTypesResource = schema.GroupVersionResource{Group: "example", Version: "v2", Resource: "testtypes"}
-var testTypesKind = schema.GroupVersionKind{Group: "example", Version: "v2", Kind: "TestType"}
+var testTypesResource = schema.GroupVersionResource{Group: "example.dev", Version: "v2", Resource: "testtypes"}
+var testTypesKind = schema.GroupVersionKind{Group: "example.dev", Version: "v2", Kind: "TestType"}
 
 type testTypesClusterClient struct {
 	*kcptesting.Fake

--- a/examples/pkg/kcp/clients/clientset/versioned/typed/secondexample/v1/fake/clustertesttype.go
+++ b/examples/pkg/kcp/clients/clientset/versioned/typed/secondexample/v1/fake/clustertesttype.go
@@ -38,8 +38,8 @@ import (
 	secondexamplev1client "acme.corp/pkg/generated/clientset/versioned/typed/secondexample/v1"
 )
 
-var clusterTestTypesResource = schema.GroupVersionResource{Group: "secondexample", Version: "v1", Resource: "clustertesttypes"}
-var clusterTestTypesKind = schema.GroupVersionKind{Group: "secondexample", Version: "v1", Kind: "ClusterTestType"}
+var clusterTestTypesResource = schema.GroupVersionResource{Group: "secondexample.dev", Version: "v1", Resource: "clustertesttypes"}
+var clusterTestTypesKind = schema.GroupVersionKind{Group: "secondexample.dev", Version: "v1", Kind: "ClusterTestType"}
 
 type clusterTestTypesClusterClient struct {
 	*kcptesting.Fake

--- a/examples/pkg/kcp/clients/clientset/versioned/typed/secondexample/v1/fake/testtype.go
+++ b/examples/pkg/kcp/clients/clientset/versioned/typed/secondexample/v1/fake/testtype.go
@@ -39,8 +39,8 @@ import (
 	kcpsecondexamplev1 "acme.corp/pkg/kcp/clients/clientset/versioned/typed/secondexample/v1"
 )
 
-var testTypesResource = schema.GroupVersionResource{Group: "secondexample", Version: "v1", Resource: "testtypes"}
-var testTypesKind = schema.GroupVersionKind{Group: "secondexample", Version: "v1", Kind: "TestType"}
+var testTypesResource = schema.GroupVersionResource{Group: "secondexample.dev", Version: "v1", Resource: "testtypes"}
+var testTypesKind = schema.GroupVersionKind{Group: "secondexample.dev", Version: "v1", Kind: "TestType"}
 
 type testTypesClusterClient struct {
 	*kcptesting.Fake

--- a/examples/pkg/kcp/clients/informers/externalversions/generic.go
+++ b/examples/pkg/kcp/clients/informers/externalversions/generic.go
@@ -100,22 +100,22 @@ func (f *sharedInformerFactory) ForResource(resource schema.GroupVersionResource
 		return &genericClusterInformer{resource: resource.GroupResource(), informer: f.Example3().V1().TestTypes().Informer()}, nil
 	case example3v1.SchemeGroupVersion.WithResource("clustertesttypes"):
 		return &genericClusterInformer{resource: resource.GroupResource(), informer: f.Example3().V1().ClusterTestTypes().Informer()}, nil
-	// Group=example, Version=V1
+	// Group=example.dev, Version=V1
 	case examplev1.SchemeGroupVersion.WithResource("testtypes"):
 		return &genericClusterInformer{resource: resource.GroupResource(), informer: f.Example().V1().TestTypes().Informer()}, nil
 	case examplev1.SchemeGroupVersion.WithResource("clustertesttypes"):
 		return &genericClusterInformer{resource: resource.GroupResource(), informer: f.Example().V1().ClusterTestTypes().Informer()}, nil
-	// Group=example, Version=V1alpha1
+	// Group=example.dev, Version=V1alpha1
 	case examplev1alpha1.SchemeGroupVersion.WithResource("testtypes"):
 		return &genericClusterInformer{resource: resource.GroupResource(), informer: f.Example().V1alpha1().TestTypes().Informer()}, nil
 	case examplev1alpha1.SchemeGroupVersion.WithResource("clustertesttypes"):
 		return &genericClusterInformer{resource: resource.GroupResource(), informer: f.Example().V1alpha1().ClusterTestTypes().Informer()}, nil
-	// Group=example, Version=V1beta1
+	// Group=example.dev, Version=V1beta1
 	case examplev1beta1.SchemeGroupVersion.WithResource("testtypes"):
 		return &genericClusterInformer{resource: resource.GroupResource(), informer: f.Example().V1beta1().TestTypes().Informer()}, nil
 	case examplev1beta1.SchemeGroupVersion.WithResource("clustertesttypes"):
 		return &genericClusterInformer{resource: resource.GroupResource(), informer: f.Example().V1beta1().ClusterTestTypes().Informer()}, nil
-	// Group=example, Version=V2
+	// Group=example.dev, Version=V2
 	case examplev2.SchemeGroupVersion.WithResource("testtypes"):
 		return &genericClusterInformer{resource: resource.GroupResource(), informer: f.Example().V2().TestTypes().Informer()}, nil
 	case examplev2.SchemeGroupVersion.WithResource("clustertesttypes"):
@@ -125,7 +125,7 @@ func (f *sharedInformerFactory) ForResource(resource schema.GroupVersionResource
 		return &genericClusterInformer{resource: resource.GroupResource(), informer: f.Existinginterfaces().V1().TestTypes().Informer()}, nil
 	case existinginterfacesv1.SchemeGroupVersion.WithResource("clustertesttypes"):
 		return &genericClusterInformer{resource: resource.GroupResource(), informer: f.Existinginterfaces().V1().ClusterTestTypes().Informer()}, nil
-	// Group=secondexample, Version=V1
+	// Group=secondexample.dev, Version=V1
 	case secondexamplev1.SchemeGroupVersion.WithResource("testtypes"):
 		return &genericClusterInformer{resource: resource.GroupResource(), informer: f.Secondexample().V1().TestTypes().Informer()}, nil
 	case secondexamplev1.SchemeGroupVersion.WithResource("clustertesttypes"):
@@ -153,28 +153,28 @@ func (f *sharedScopedInformerFactory) ForResource(resource schema.GroupVersionRe
 	case example3v1.SchemeGroupVersion.WithResource("clustertesttypes"):
 		informer := f.Example3().V1().ClusterTestTypes().Informer()
 		return &genericInformer{lister: cache.NewGenericLister(informer.GetIndexer(), resource.GroupResource()), informer: informer}, nil
-	// Group=example, Version=V1
+	// Group=example.dev, Version=V1
 	case examplev1.SchemeGroupVersion.WithResource("testtypes"):
 		informer := f.Example().V1().TestTypes().Informer()
 		return &genericInformer{lister: cache.NewGenericLister(informer.GetIndexer(), resource.GroupResource()), informer: informer}, nil
 	case examplev1.SchemeGroupVersion.WithResource("clustertesttypes"):
 		informer := f.Example().V1().ClusterTestTypes().Informer()
 		return &genericInformer{lister: cache.NewGenericLister(informer.GetIndexer(), resource.GroupResource()), informer: informer}, nil
-	// Group=example, Version=V1alpha1
+	// Group=example.dev, Version=V1alpha1
 	case examplev1alpha1.SchemeGroupVersion.WithResource("testtypes"):
 		informer := f.Example().V1alpha1().TestTypes().Informer()
 		return &genericInformer{lister: cache.NewGenericLister(informer.GetIndexer(), resource.GroupResource()), informer: informer}, nil
 	case examplev1alpha1.SchemeGroupVersion.WithResource("clustertesttypes"):
 		informer := f.Example().V1alpha1().ClusterTestTypes().Informer()
 		return &genericInformer{lister: cache.NewGenericLister(informer.GetIndexer(), resource.GroupResource()), informer: informer}, nil
-	// Group=example, Version=V1beta1
+	// Group=example.dev, Version=V1beta1
 	case examplev1beta1.SchemeGroupVersion.WithResource("testtypes"):
 		informer := f.Example().V1beta1().TestTypes().Informer()
 		return &genericInformer{lister: cache.NewGenericLister(informer.GetIndexer(), resource.GroupResource()), informer: informer}, nil
 	case examplev1beta1.SchemeGroupVersion.WithResource("clustertesttypes"):
 		informer := f.Example().V1beta1().ClusterTestTypes().Informer()
 		return &genericInformer{lister: cache.NewGenericLister(informer.GetIndexer(), resource.GroupResource()), informer: informer}, nil
-	// Group=example, Version=V2
+	// Group=example.dev, Version=V2
 	case examplev2.SchemeGroupVersion.WithResource("testtypes"):
 		informer := f.Example().V2().TestTypes().Informer()
 		return &genericInformer{lister: cache.NewGenericLister(informer.GetIndexer(), resource.GroupResource()), informer: informer}, nil
@@ -188,7 +188,7 @@ func (f *sharedScopedInformerFactory) ForResource(resource schema.GroupVersionRe
 	case existinginterfacesv1.SchemeGroupVersion.WithResource("clustertesttypes"):
 		informer := f.Existinginterfaces().V1().ClusterTestTypes().Informer()
 		return &genericInformer{lister: cache.NewGenericLister(informer.GetIndexer(), resource.GroupResource()), informer: informer}, nil
-	// Group=secondexample, Version=V1
+	// Group=secondexample.dev, Version=V1
 	case secondexamplev1.SchemeGroupVersion.WithResource("testtypes"):
 		informer := f.Secondexample().V1().TestTypes().Informer()
 		return &genericInformer{lister: cache.NewGenericLister(informer.GetIndexer(), resource.GroupResource()), informer: informer}, nil

--- a/examples/pkg/kcpexisting/clients/clientset/versioned/typed/example/v1/fake/clustertesttype.go
+++ b/examples/pkg/kcpexisting/clients/clientset/versioned/typed/example/v1/fake/clustertesttype.go
@@ -38,8 +38,8 @@ import (
 	examplev1client "acme.corp/pkg/generated/clientset/versioned/typed/example/v1"
 )
 
-var clusterTestTypesResource = schema.GroupVersionResource{Group: "example", Version: "v1", Resource: "clustertesttypes"}
-var clusterTestTypesKind = schema.GroupVersionKind{Group: "example", Version: "v1", Kind: "ClusterTestType"}
+var clusterTestTypesResource = schema.GroupVersionResource{Group: "example.dev", Version: "v1", Resource: "clustertesttypes"}
+var clusterTestTypesKind = schema.GroupVersionKind{Group: "example.dev", Version: "v1", Kind: "ClusterTestType"}
 
 type clusterTestTypesClusterClient struct {
 	*kcptesting.Fake

--- a/examples/pkg/kcpexisting/clients/clientset/versioned/typed/example/v1/fake/testtype.go
+++ b/examples/pkg/kcpexisting/clients/clientset/versioned/typed/example/v1/fake/testtype.go
@@ -39,8 +39,8 @@ import (
 	kcpexamplev1 "acme.corp/pkg/kcpexisting/clients/clientset/versioned/typed/example/v1"
 )
 
-var testTypesResource = schema.GroupVersionResource{Group: "example", Version: "v1", Resource: "testtypes"}
-var testTypesKind = schema.GroupVersionKind{Group: "example", Version: "v1", Kind: "TestType"}
+var testTypesResource = schema.GroupVersionResource{Group: "example.dev", Version: "v1", Resource: "testtypes"}
+var testTypesKind = schema.GroupVersionKind{Group: "example.dev", Version: "v1", Kind: "TestType"}
 
 type testTypesClusterClient struct {
 	*kcptesting.Fake

--- a/examples/pkg/kcpexisting/clients/clientset/versioned/typed/example/v1/fake/withoutverbtype.go
+++ b/examples/pkg/kcpexisting/clients/clientset/versioned/typed/example/v1/fake/withoutverbtype.go
@@ -28,8 +28,8 @@ import (
 	kcpexamplev1 "acme.corp/pkg/kcpexisting/clients/clientset/versioned/typed/example/v1"
 )
 
-var withoutVerbTypesResource = schema.GroupVersionResource{Group: "example", Version: "v1", Resource: "withoutverbtypes"}
-var withoutVerbTypesKind = schema.GroupVersionKind{Group: "example", Version: "v1", Kind: "WithoutVerbType"}
+var withoutVerbTypesResource = schema.GroupVersionResource{Group: "example.dev", Version: "v1", Resource: "withoutverbtypes"}
+var withoutVerbTypesKind = schema.GroupVersionKind{Group: "example.dev", Version: "v1", Kind: "WithoutVerbType"}
 
 type withoutVerbTypesClusterClient struct {
 	*kcptesting.Fake

--- a/examples/pkg/kcpexisting/clients/clientset/versioned/typed/example/v1alpha1/fake/clustertesttype.go
+++ b/examples/pkg/kcpexisting/clients/clientset/versioned/typed/example/v1alpha1/fake/clustertesttype.go
@@ -38,8 +38,8 @@ import (
 	examplev1alpha1client "acme.corp/pkg/generated/clientset/versioned/typed/example/v1alpha1"
 )
 
-var clusterTestTypesResource = schema.GroupVersionResource{Group: "example", Version: "v1alpha1", Resource: "clustertesttypes"}
-var clusterTestTypesKind = schema.GroupVersionKind{Group: "example", Version: "v1alpha1", Kind: "ClusterTestType"}
+var clusterTestTypesResource = schema.GroupVersionResource{Group: "example.dev", Version: "v1alpha1", Resource: "clustertesttypes"}
+var clusterTestTypesKind = schema.GroupVersionKind{Group: "example.dev", Version: "v1alpha1", Kind: "ClusterTestType"}
 
 type clusterTestTypesClusterClient struct {
 	*kcptesting.Fake

--- a/examples/pkg/kcpexisting/clients/clientset/versioned/typed/example/v1alpha1/fake/testtype.go
+++ b/examples/pkg/kcpexisting/clients/clientset/versioned/typed/example/v1alpha1/fake/testtype.go
@@ -39,8 +39,8 @@ import (
 	kcpexamplev1alpha1 "acme.corp/pkg/kcpexisting/clients/clientset/versioned/typed/example/v1alpha1"
 )
 
-var testTypesResource = schema.GroupVersionResource{Group: "example", Version: "v1alpha1", Resource: "testtypes"}
-var testTypesKind = schema.GroupVersionKind{Group: "example", Version: "v1alpha1", Kind: "TestType"}
+var testTypesResource = schema.GroupVersionResource{Group: "example.dev", Version: "v1alpha1", Resource: "testtypes"}
+var testTypesKind = schema.GroupVersionKind{Group: "example.dev", Version: "v1alpha1", Kind: "TestType"}
 
 type testTypesClusterClient struct {
 	*kcptesting.Fake

--- a/examples/pkg/kcpexisting/clients/clientset/versioned/typed/example/v1beta1/fake/clustertesttype.go
+++ b/examples/pkg/kcpexisting/clients/clientset/versioned/typed/example/v1beta1/fake/clustertesttype.go
@@ -38,8 +38,8 @@ import (
 	examplev1beta1client "acme.corp/pkg/generated/clientset/versioned/typed/example/v1beta1"
 )
 
-var clusterTestTypesResource = schema.GroupVersionResource{Group: "example", Version: "v1beta1", Resource: "clustertesttypes"}
-var clusterTestTypesKind = schema.GroupVersionKind{Group: "example", Version: "v1beta1", Kind: "ClusterTestType"}
+var clusterTestTypesResource = schema.GroupVersionResource{Group: "example.dev", Version: "v1beta1", Resource: "clustertesttypes"}
+var clusterTestTypesKind = schema.GroupVersionKind{Group: "example.dev", Version: "v1beta1", Kind: "ClusterTestType"}
 
 type clusterTestTypesClusterClient struct {
 	*kcptesting.Fake

--- a/examples/pkg/kcpexisting/clients/clientset/versioned/typed/example/v1beta1/fake/testtype.go
+++ b/examples/pkg/kcpexisting/clients/clientset/versioned/typed/example/v1beta1/fake/testtype.go
@@ -39,8 +39,8 @@ import (
 	kcpexamplev1beta1 "acme.corp/pkg/kcpexisting/clients/clientset/versioned/typed/example/v1beta1"
 )
 
-var testTypesResource = schema.GroupVersionResource{Group: "example", Version: "v1beta1", Resource: "testtypes"}
-var testTypesKind = schema.GroupVersionKind{Group: "example", Version: "v1beta1", Kind: "TestType"}
+var testTypesResource = schema.GroupVersionResource{Group: "example.dev", Version: "v1beta1", Resource: "testtypes"}
+var testTypesKind = schema.GroupVersionKind{Group: "example.dev", Version: "v1beta1", Kind: "TestType"}
 
 type testTypesClusterClient struct {
 	*kcptesting.Fake

--- a/examples/pkg/kcpexisting/clients/clientset/versioned/typed/example/v2/fake/clustertesttype.go
+++ b/examples/pkg/kcpexisting/clients/clientset/versioned/typed/example/v2/fake/clustertesttype.go
@@ -38,8 +38,8 @@ import (
 	examplev2client "acme.corp/pkg/generated/clientset/versioned/typed/example/v2"
 )
 
-var clusterTestTypesResource = schema.GroupVersionResource{Group: "example", Version: "v2", Resource: "clustertesttypes"}
-var clusterTestTypesKind = schema.GroupVersionKind{Group: "example", Version: "v2", Kind: "ClusterTestType"}
+var clusterTestTypesResource = schema.GroupVersionResource{Group: "example.dev", Version: "v2", Resource: "clustertesttypes"}
+var clusterTestTypesKind = schema.GroupVersionKind{Group: "example.dev", Version: "v2", Kind: "ClusterTestType"}
 
 type clusterTestTypesClusterClient struct {
 	*kcptesting.Fake

--- a/examples/pkg/kcpexisting/clients/clientset/versioned/typed/example/v2/fake/testtype.go
+++ b/examples/pkg/kcpexisting/clients/clientset/versioned/typed/example/v2/fake/testtype.go
@@ -39,8 +39,8 @@ import (
 	kcpexamplev2 "acme.corp/pkg/kcpexisting/clients/clientset/versioned/typed/example/v2"
 )
 
-var testTypesResource = schema.GroupVersionResource{Group: "example", Version: "v2", Resource: "testtypes"}
-var testTypesKind = schema.GroupVersionKind{Group: "example", Version: "v2", Kind: "TestType"}
+var testTypesResource = schema.GroupVersionResource{Group: "example.dev", Version: "v2", Resource: "testtypes"}
+var testTypesKind = schema.GroupVersionKind{Group: "example.dev", Version: "v2", Kind: "TestType"}
 
 type testTypesClusterClient struct {
 	*kcptesting.Fake

--- a/examples/pkg/kcpexisting/clients/clientset/versioned/typed/secondexample/v1/fake/clustertesttype.go
+++ b/examples/pkg/kcpexisting/clients/clientset/versioned/typed/secondexample/v1/fake/clustertesttype.go
@@ -38,8 +38,8 @@ import (
 	secondexamplev1client "acme.corp/pkg/generated/clientset/versioned/typed/secondexample/v1"
 )
 
-var clusterTestTypesResource = schema.GroupVersionResource{Group: "secondexample", Version: "v1", Resource: "clustertesttypes"}
-var clusterTestTypesKind = schema.GroupVersionKind{Group: "secondexample", Version: "v1", Kind: "ClusterTestType"}
+var clusterTestTypesResource = schema.GroupVersionResource{Group: "secondexample.dev", Version: "v1", Resource: "clustertesttypes"}
+var clusterTestTypesKind = schema.GroupVersionKind{Group: "secondexample.dev", Version: "v1", Kind: "ClusterTestType"}
 
 type clusterTestTypesClusterClient struct {
 	*kcptesting.Fake

--- a/examples/pkg/kcpexisting/clients/clientset/versioned/typed/secondexample/v1/fake/testtype.go
+++ b/examples/pkg/kcpexisting/clients/clientset/versioned/typed/secondexample/v1/fake/testtype.go
@@ -39,8 +39,8 @@ import (
 	kcpsecondexamplev1 "acme.corp/pkg/kcpexisting/clients/clientset/versioned/typed/secondexample/v1"
 )
 
-var testTypesResource = schema.GroupVersionResource{Group: "secondexample", Version: "v1", Resource: "testtypes"}
-var testTypesKind = schema.GroupVersionKind{Group: "secondexample", Version: "v1", Kind: "TestType"}
+var testTypesResource = schema.GroupVersionResource{Group: "secondexample.dev", Version: "v1", Resource: "testtypes"}
+var testTypesKind = schema.GroupVersionKind{Group: "secondexample.dev", Version: "v1", Kind: "TestType"}
 
 type testTypesClusterClient struct {
 	*kcptesting.Fake

--- a/examples/pkg/kcpexisting/clients/informers/externalversions/generic.go
+++ b/examples/pkg/kcpexisting/clients/informers/externalversions/generic.go
@@ -96,22 +96,22 @@ func (f *sharedInformerFactory) ForResource(resource schema.GroupVersionResource
 		return &genericClusterInformer{resource: resource.GroupResource(), informer: f.Example3().V1().TestTypes().Informer()}, nil
 	case example3v1.SchemeGroupVersion.WithResource("clustertesttypes"):
 		return &genericClusterInformer{resource: resource.GroupResource(), informer: f.Example3().V1().ClusterTestTypes().Informer()}, nil
-	// Group=example, Version=V1
+	// Group=example.dev, Version=V1
 	case examplev1.SchemeGroupVersion.WithResource("testtypes"):
 		return &genericClusterInformer{resource: resource.GroupResource(), informer: f.Example().V1().TestTypes().Informer()}, nil
 	case examplev1.SchemeGroupVersion.WithResource("clustertesttypes"):
 		return &genericClusterInformer{resource: resource.GroupResource(), informer: f.Example().V1().ClusterTestTypes().Informer()}, nil
-	// Group=example, Version=V1alpha1
+	// Group=example.dev, Version=V1alpha1
 	case examplev1alpha1.SchemeGroupVersion.WithResource("testtypes"):
 		return &genericClusterInformer{resource: resource.GroupResource(), informer: f.Example().V1alpha1().TestTypes().Informer()}, nil
 	case examplev1alpha1.SchemeGroupVersion.WithResource("clustertesttypes"):
 		return &genericClusterInformer{resource: resource.GroupResource(), informer: f.Example().V1alpha1().ClusterTestTypes().Informer()}, nil
-	// Group=example, Version=V1beta1
+	// Group=example.dev, Version=V1beta1
 	case examplev1beta1.SchemeGroupVersion.WithResource("testtypes"):
 		return &genericClusterInformer{resource: resource.GroupResource(), informer: f.Example().V1beta1().TestTypes().Informer()}, nil
 	case examplev1beta1.SchemeGroupVersion.WithResource("clustertesttypes"):
 		return &genericClusterInformer{resource: resource.GroupResource(), informer: f.Example().V1beta1().ClusterTestTypes().Informer()}, nil
-	// Group=example, Version=V2
+	// Group=example.dev, Version=V2
 	case examplev2.SchemeGroupVersion.WithResource("testtypes"):
 		return &genericClusterInformer{resource: resource.GroupResource(), informer: f.Example().V2().TestTypes().Informer()}, nil
 	case examplev2.SchemeGroupVersion.WithResource("clustertesttypes"):
@@ -121,7 +121,7 @@ func (f *sharedInformerFactory) ForResource(resource schema.GroupVersionResource
 		return &genericClusterInformer{resource: resource.GroupResource(), informer: f.Existinginterfaces().V1().TestTypes().Informer()}, nil
 	case existinginterfacesv1.SchemeGroupVersion.WithResource("clustertesttypes"):
 		return &genericClusterInformer{resource: resource.GroupResource(), informer: f.Existinginterfaces().V1().ClusterTestTypes().Informer()}, nil
-	// Group=secondexample, Version=V1
+	// Group=secondexample.dev, Version=V1
 	case secondexamplev1.SchemeGroupVersion.WithResource("testtypes"):
 		return &genericClusterInformer{resource: resource.GroupResource(), informer: f.Secondexample().V1().TestTypes().Informer()}, nil
 	case secondexamplev1.SchemeGroupVersion.WithResource("clustertesttypes"):

--- a/examples/test/kcp/controller_test.go
+++ b/examples/test/kcp/controller_test.go
@@ -1,0 +1,101 @@
+/*
+Copyright 2025 The KCP Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package kcp
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/kcp-dev/logicalcluster/v3"
+
+	clienttesting "github.com/kcp-dev/client-go/third_party/k8s.io/client-go/testing"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/util/wait"
+	"k8s.io/apimachinery/pkg/watch"
+	"k8s.io/client-go/tools/cache"
+
+	examplev1 "acme.corp/pkg/apis/example/v1"
+	"acme.corp/pkg/kcp/clients/clientset/versioned/fake"
+	informers "acme.corp/pkg/kcp/clients/informers/externalversions"
+)
+
+// TestFakeClient demonstrates how to use a fake client with SharedInformerFactory in tests.
+func TestFakeClient(t *testing.T) {
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	watcherStarted := make(chan struct{})
+	// Create the fake client.
+	client := fake.NewSimpleClientset()
+	// A catch-all watch reactor that allows us to inject the watcherStarted channel.
+	client.PrependWatchReactor("*", func(action clienttesting.Action) (handled bool, ret watch.Interface, err error) {
+		gvr := action.GetResource()
+		ns := action.GetNamespace()
+		watch, err := client.Tracker().Watch(gvr, ns)
+		if err != nil {
+			return false, nil, err
+		}
+		close(watcherStarted)
+		return true, watch, nil
+	})
+
+	// We will create an informer that writes added testTypes to a channel.
+	testTypes := make(chan *examplev1.TestType, 1)
+	informerFactory := informers.NewSharedInformerFactory(client, 0)
+	testTypeInformer := informerFactory.Example().V1().TestTypes().Informer()
+	if _, err := testTypeInformer.AddEventHandler(&cache.ResourceEventHandlerFuncs{
+		AddFunc: func(obj interface{}) {
+			testType := obj.(*examplev1.TestType)
+			t.Logf("testType added: %s/%s", testType.Namespace, testType.Name)
+			testTypes <- testType
+		},
+	}); err != nil {
+		t.Fatalf("Failed to add event handler: %v", err)
+	}
+
+	// Make sure informers are running.
+	informerFactory.Cluster(logicalcluster.Name("root")).Start(ctx.Done())
+
+	// This is not required in tests, but it serves as a proof-of-concept by
+	// ensuring that the informer goroutine have warmed up and called List before
+	// we send any events to it.
+	cache.WaitForCacheSync(ctx.Done(), testTypeInformer.HasSynced)
+
+	// The fake client doesn't support resource version. Any writes to the client
+	// after the informer's initial LIST and before the informer establishing the
+	// watcher will be missed by the informer. Therefore we wait until the watcher
+	// starts.
+	// Note that the fake client isn't designed to work with informer. It
+	// doesn't support resource version. It's encouraged to use a real client
+	// in an integration/E2E test if you need to test complex behavior with
+	// informer/controllers.
+	<-watcherStarted
+	// Inject an event into the fake client.
+	p := &examplev1.TestType{ObjectMeta: metav1.ObjectMeta{Name: "my-testobj"}}
+	_, err := client.ExampleV1().TestTypes().Cluster(logicalcluster.NewPath("root")).Namespace("test-ns").Create(ctx, p, metav1.CreateOptions{})
+	if err != nil {
+		t.Fatalf("error injecting testType add: %v", err)
+	}
+
+	select {
+	case testType := <-testTypes:
+		t.Logf("Got testType from channel: %s/%s", testType.Namespace, testType.Name)
+	case <-time.After(wait.ForeverTestTimeout):
+		t.Error("Informer did not get the added testType")
+	}
+}

--- a/examples/test/kcpexisting/controller_test.go
+++ b/examples/test/kcpexisting/controller_test.go
@@ -1,0 +1,101 @@
+/*
+Copyright 2025 The KCP Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package kcpexisting
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/kcp-dev/logicalcluster/v3"
+
+	clienttesting "github.com/kcp-dev/client-go/third_party/k8s.io/client-go/testing"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/util/wait"
+	"k8s.io/apimachinery/pkg/watch"
+	"k8s.io/client-go/tools/cache"
+
+	examplev1 "acme.corp/pkg/apis/example/v1"
+	"acme.corp/pkg/kcpexisting/clients/clientset/versioned/fake"
+	informers "acme.corp/pkg/kcpexisting/clients/informers/externalversions"
+)
+
+// TestFakeClient demonstrates how to use a fake client with SharedInformerFactory in tests.
+func TestFakeClient(t *testing.T) {
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	watcherStarted := make(chan struct{})
+	// Create the fake client.
+	client := fake.NewSimpleClientset()
+	// A catch-all watch reactor that allows us to inject the watcherStarted channel.
+	client.PrependWatchReactor("*", func(action clienttesting.Action) (handled bool, ret watch.Interface, err error) {
+		gvr := action.GetResource()
+		ns := action.GetNamespace()
+		watch, err := client.Tracker().Watch(gvr, ns)
+		if err != nil {
+			return false, nil, err
+		}
+		close(watcherStarted)
+		return true, watch, nil
+	})
+
+	// We will create an informer that writes added testTypes to a channel.
+	testTypes := make(chan *examplev1.TestType, 1)
+	informerFactory := informers.NewSharedInformerFactory(client, 0)
+	testTypeInformer := informerFactory.Example().V1().TestTypes().Informer()
+	if _, err := testTypeInformer.AddEventHandler(&cache.ResourceEventHandlerFuncs{
+		AddFunc: func(obj interface{}) {
+			testType := obj.(*examplev1.TestType)
+			t.Logf("testType added: %s/%s", testType.Namespace, testType.Name)
+			testTypes <- testType
+		},
+	}); err != nil {
+		t.Fatalf("Failed to add event handler: %v", err)
+	}
+
+	// Make sure informers are running.
+	informerFactory.Cluster(logicalcluster.Name("root")).Start(ctx.Done())
+
+	// This is not required in tests, but it serves as a proof-of-concept by
+	// ensuring that the informer goroutine have warmed up and called List before
+	// we send any events to it.
+	cache.WaitForCacheSync(ctx.Done(), testTypeInformer.HasSynced)
+
+	// The fake client doesn't support resource version. Any writes to the client
+	// after the informer's initial LIST and before the informer establishing the
+	// watcher will be missed by the informer. Therefore we wait until the watcher
+	// starts.
+	// Note that the fake client isn't designed to work with informer. It
+	// doesn't support resource version. It's encouraged to use a real client
+	// in an integration/E2E test if you need to test complex behavior with
+	// informer/controllers.
+	<-watcherStarted
+	// Inject an event into the fake client.
+	p := &examplev1.TestType{ObjectMeta: metav1.ObjectMeta{Name: "my-testobj"}}
+	_, err := client.ExampleV1().TestTypes().Cluster(logicalcluster.NewPath("root")).Namespace("test-ns").Create(ctx, p, metav1.CreateOptions{})
+	if err != nil {
+		t.Fatalf("error injecting testType add: %v", err)
+	}
+
+	select {
+	case testType := <-testTypes:
+		t.Logf("Got testType from channel: %s/%s", testType.Namespace, testType.Name)
+	case <-time.After(wait.ForeverTestTimeout):
+		t.Error("Informer did not get the added testType")
+	}
+}

--- a/examples/test/singlecluster/controller_test.go
+++ b/examples/test/singlecluster/controller_test.go
@@ -1,0 +1,99 @@
+/*
+Copyright 2025 The KCP Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package singlecluster
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/util/wait"
+	"k8s.io/apimachinery/pkg/watch"
+	clienttesting "k8s.io/client-go/testing"
+	"k8s.io/client-go/tools/cache"
+
+	examplev1 "acme.corp/pkg/apis/example/v1"
+	"acme.corp/pkg/generated/clientset/versioned/fake"
+	informers "acme.corp/pkg/generated/informers/externalversions"
+)
+
+// TestFakeClient demonstrates how to use a fake client with SharedInformerFactory in tests.
+func TestFakeClient(t *testing.T) {
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	watcherStarted := make(chan struct{})
+	// Create the fake client.
+	client := fake.NewSimpleClientset()
+	// A catch-all watch reactor that allows us to inject the watcherStarted channel.
+	client.PrependWatchReactor("*", func(action clienttesting.Action) (handled bool, ret watch.Interface, err error) {
+		gvr := action.GetResource()
+		ns := action.GetNamespace()
+		watch, err := client.Tracker().Watch(gvr, ns)
+		if err != nil {
+			return false, nil, err
+		}
+		close(watcherStarted)
+		return true, watch, nil
+	})
+
+	// We will create an informer that writes added testTypes to a channel.
+	testTypes := make(chan *examplev1.TestType, 1)
+	informerFactory := informers.NewSharedInformerFactory(client, 0)
+	testTypeInformer := informerFactory.Example().V1().TestTypes().Informer()
+	if _, err := testTypeInformer.AddEventHandler(&cache.ResourceEventHandlerFuncs{
+		AddFunc: func(obj interface{}) {
+			testType := obj.(*examplev1.TestType)
+			t.Logf("testType added: %s/%s", testType.Namespace, testType.Name)
+			testTypes <- testType
+		},
+	}); err != nil {
+		t.Fatalf("Failed to add event handler: %v", err)
+	}
+
+	// Make sure informers are running.
+	informerFactory.Start(ctx.Done())
+
+	// This is not required in tests, but it serves as a proof-of-concept by
+	// ensuring that the informer goroutine have warmed up and called List before
+	// we send any events to it.
+	cache.WaitForCacheSync(ctx.Done(), testTypeInformer.HasSynced)
+
+	// The fake client doesn't support resource version. Any writes to the client
+	// after the informer's initial LIST and before the informer establishing the
+	// watcher will be missed by the informer. Therefore we wait until the watcher
+	// starts.
+	// Note that the fake client isn't designed to work with informer. It
+	// doesn't support resource version. It's encouraged to use a real client
+	// in an integration/E2E test if you need to test complex behavior with
+	// informer/controllers.
+	<-watcherStarted
+	// Inject an event into the fake client.
+	p := &examplev1.TestType{ObjectMeta: metav1.ObjectMeta{Name: "my-testobj"}}
+	_, err := client.ExampleV1().TestTypes("test-ns").Create(ctx, p, metav1.CreateOptions{})
+	if err != nil {
+		t.Fatalf("error injecting testType add: %v", err)
+	}
+
+	select {
+	case testType := <-testTypes:
+		t.Logf("Got testType from channel: %s/%s", testType.Namespace, testType.Name)
+	case <-time.After(wait.ForeverTestTimeout):
+		t.Error("Informer did not get the added testType")
+	}
+}


### PR DESCRIPTION
## Summary
I am not sure why, but the various GroupName constants and +groupName comments were widely inconsistent in the examples. That lead to a working codegen, but when trying to actually use the generated fake client, one would end with errors like 

> W0422 13:58:15.416218  201389 reflector.go:569] pkg/mod/k8s.io/client-go@v0.32.0/tools/cache/reflector.go:251: failed to list *v1.TestType: no kind "TestTypeList" is registered for version "example/v1" in scheme "pkg/runtime/scheme.go:100"

Note the API group `example`, which is neither `example.dev` nor `example.some.corp` and so things won't work.

It is also seemingly necessary to attach a +groupName to the doc.go of every version, not just their parent package.

I included the three sample tests I adopted from upstream. They helped me ensure it's all working and I guess can help us ensure it keeps working, so I added testing the examples module to `make test`.

## Release Notes
```release-note
Fix inconsistent API groups in the example APIs
```
